### PR TITLE
mealie: move from Home to Users group

### DIFF
--- a/modules/apps/mealie-blueprints/mealie.yaml
+++ b/modules/apps/mealie-blueprints/mealie.yaml
@@ -34,7 +34,7 @@ entries:
     attrs:
       name: Mealie
       provider: !KeyOf prov-mealie
-      group: Home
+      group: Users
       open_in_new_tab: true
       meta_launch_url: https://mealie.dnix.ipreston.net
       meta_icon: https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/png/mealie.png
@@ -43,7 +43,7 @@ entries:
       # binding to pass.
       policy_engine_mode: all
 
-  # Restrict the application to members of the Home group. Mealie also
+  # Restrict the application to members of the Users group. Mealie also
   # gates login at its end via OIDC_USER_GROUP, but pinning the binding
   # here keeps the launcher tile hidden for users who can't use it.
   - model: authentik_policies.policybinding
@@ -51,5 +51,5 @@ entries:
       target: !KeyOf app-mealie
       order: 0
     attrs:
-      group: !Find [authentik_core.group, [name, Home]]
+      group: !Find [authentik_core.group, [name, Users]]
       enabled: true

--- a/modules/apps/mealie.nix
+++ b/modules/apps/mealie.nix
@@ -158,7 +158,7 @@ in
           OIDC_AUTH_ENABLED = "true";
           OIDC_PROVIDER_NAME = "Authentik";
           OIDC_CONFIGURATION_URL = "https://${authentikHost}/application/o/mealie/.well-known/openid-configuration";
-          OIDC_USER_GROUP = "Home";
+          OIDC_USER_GROUP = "Users";
           OIDC_ADMIN_GROUP = "authentik Admins";
           OIDC_AUTO_REDIRECT = "false";
           OIDC_REMEMBER_ME = "true";


### PR DESCRIPTION
## Summary
- Mealie was gated to the `Home` group, which is reserved for more restricted apps. Move the application launcher group, the policy binding, and `OIDC_USER_GROUP` to `Users` so anyone in Users can launch and sign in.

Closes #80

## Test plan
- [x] `task check`
- [ ] Deploy to hpp-1 and confirm: Mealie tile appears in launcher for a Users-only account, and SSO login completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)