### PR TITLE
add hpp-1 + testvm to build-all — closes #143

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,7 +33,15 @@ tasks:
     cmds:
       - nix build .#nixosConfigurations.{{.HOST}}.config.system.build.toplevel
   build-all:
-    desc: Build all NixOS host configurations
+    desc: Build all NixOS host configurations (full pre-push set, includes servers)
+    cmds:
+      - nix build .#nixosConfigurations.luna.config.system.build.toplevel
+      - nix build .#nixosConfigurations.terra.config.system.build.toplevel
+      - nix build .#nixosConfigurations.toshibachromebook.config.system.build.toplevel
+      - nix build .#nixosConfigurations.testvm.config.system.build.toplevel
+      - nix build .#nixosConfigurations.hpp-1.config.system.build.toplevel
+  build-fast:
+    desc: Build workstation/laptop hosts only (skip servers for inner dev loop)
     cmds:
       - nix build .#nixosConfigurations.luna.config.system.build.toplevel
       - nix build .#nixosConfigurations.terra.config.system.build.toplevel


### PR DESCRIPTION
## Summary
- Closes #143. `task build-all` previously skipped `hpp-1`, the most-deployed and highest-risk host (nightly `system.autoUpgrade`), as well as `testvm`. Add both to the full pre-push set.
- Add a new `task build-fast` that builds only workstation/laptop hosts (luna, terra, toshibachromebook) — fast inner dev loop while `build-all` stays comprehensive.
- No Nix code touched; pure Taskfile change.

## Test plan
- [x] `task --list` parses cleanly and surfaces both `build-all` and `build-fast`.
- [ ] `task build-all` on a linux builder builds all five host configs (luna, terra, toshibachromebook, testvm, hpp-1) green.
- [ ] `task build-fast` builds the three workstation hosts only.

This pull request and its description were written by Isaac.