### PR TITLE
pin configurationLimit + raise server GC retention to 30d

### DIFF
--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -30,6 +30,15 @@ in
       hardware.enableRedistributableFirmware = true;
       nixpkgs.config.allowUnfree = true;
 
+      # Keep 20 boot generations rather than the systemd-boot default
+      # of unlimited (which still gets culled by nix-gc retention).
+      # Pairs with the 30d GC retention in nix-maintenance.nix so that
+      # `auto-rebuild` regressions remain rollback-able past the
+      # weekly upgrade cadence. Harmless on hosts that don't enable
+      # systemd-boot (e.g. toshibachromebook on grub) — the option is
+      # only read by the systemd-boot installer. See issue #134.
+      boot.loader.systemd-boot.configurationLimit = lib.mkDefault 20;
+
       # System-wide packages
       environment.systemPackages = with pkgs; [
         openssh

--- a/modules/system/nix-maintenance.nix
+++ b/modules/system/nix-maintenance.nix
@@ -5,10 +5,15 @@
 # substitution of large closures.
 _: {
   flake.modules.nixos.nix-maintenance = _: {
+    # Keep four weeks of generations so a subtly-broken auto-upgrade
+    # (e.g. an app's HTTP listener regressed but the unit still starts)
+    # has rollback targets even if it goes unnoticed past the weekly
+    # auto-rebuild cadence. ~1-2 GiB extra in /nix/store is trivial vs.
+    # losing every known-good generation. See issue #134.
     nix.gc = {
       automatic = true;
       dates = "weekly";
-      options = "--delete-older-than 7d";
+      options = "--delete-older-than 30d";
       persistent = true;
     };
 


### PR DESCRIPTION
## Summary

Closes #134.

- Pin `boot.loader.systemd-boot.configurationLimit = 20` in `modules/profiles/base.nix` (every NixOS host inherits via the base profile). Set with `lib.mkDefault` so a host can override if needed. Safe on grub hosts (toshibachromebook) — the option is just stored, the systemd-boot installer never reads it.
- Raise `nix.gc` retention in `modules/system/nix-maintenance.nix` from `--delete-older-than 7d` to `30d`. Picked retention bump over decoupling GC onto its own schedule because it's a one-line change (issue noted either was acceptable) and gives ~four weeks of rollback runway past the weekly `auto-rebuild` cadence.

## Why

`auto-rebuild` runs weekly. With 7d GC retention and unlimited boot entries (but generations GC'd at 7d), a latent regression that doesn't surface for >7 days leaves no known-good generation to roll back to. #123 was exactly that shape. Cost: ~1-2 GiB extra in `/nix/store` per host, which is trivial.

## Test plan

- [x] `nixfmt` clean
- [x] `task lint` (statix + deadnix) clean
- [x] `nix flake check --all-systems` passes
- [x] `nix eval .#nixosConfigurations.hpp-1.config.boot.loader.systemd-boot.configurationLimit` → `20`
- [x] `nix eval .#nixosConfigurations.toshibachromebook.config.boot.loader.systemd-boot.configurationLimit` → `20` (coexists with grub config)
- [x] `nix eval .#nixosConfigurations.hpp-1.config.nix.gc.options` → `"--delete-older-than 30d"`
- [ ] Observe on next deploy that systemd-boot installer respects the new limit (`bootctl list` after a few rebuilds)

This pull request and its description were written by Isaac.