### PR TITLE
add preservation entries for native arrs + readeck — closes #136

### DIFF
--- a/modules/apps/unifi.nix
+++ b/modules/apps/unifi.nix
@@ -67,6 +67,16 @@
         ''
       );
 
+      # UniFi state lives at /var/lib/unifi-os-server (the upstream
+      # module's `stateDir` default), NOT under /var/lib/containers —
+      # the controller's mongodb data, adoption keys, and site config
+      # all sit there. The wholesale `/var/lib/containers` preservation
+      # entry in preservation-server.nix doesn't cover it, so add an
+      # explicit one. Owner stays root:root because the upstream
+      # tmpfiles rules create the tree as root and bind-mount it into
+      # the container.
+      preservation.preserveAt."/persist".directories = [ "/var/lib/unifi-os-server" ];
+
       myAuthentik.forwardAuthApps.unifi = {
         port = 11443;
         displayName = "UniFi";

--- a/modules/profiles/server-apps.nix
+++ b/modules/profiles/server-apps.nix
@@ -5,38 +5,125 @@
 #
 # This is a flake-parts module that registers:
 # - flake.modules.nixos.server-apps (NixOS app bundle)
+#
+# Structural guard at the bottom: every native server-app with
+# persistent state on /var/lib/<app> must have a matching
+# `preservation.preserveAt."/persist".directories` entry. See the
+# block-level comment above `expectedPreservedDirs` for the rationale.
 { inputs, ... }:
 {
-  flake.modules.nixos.server-apps = _: {
-    imports = with inputs.self.modules.nixos; [
-      actualbudget
-      audiobookshelf
-      bazarr
-      grimmory
-      homeassistant
-      jellyfin
-      kapowarr
-      kavita
-      komga
-      maintainerr
-      mealie
-      miniflux
-      mylar3
-      paperless-ngx
-      profilarr
-      prowlarr
-      radarr
-      readeck
-      readmeabook
-      sabnzbd
-      seerr
-      shelfarr
-      sonarr
-      spierscraper
-      tandoor
-      unifi
-      valheim
-      watchstate
-    ];
-  };
+  flake.modules.nixos.server-apps =
+    { config, lib, ... }:
+    let
+      # Native server-apps (and the one container-app whose volumes
+      # live outside /var/lib/containers) that need an explicit
+      # preservation entry on impermanence hosts. Container-only apps
+      # (kapowarr, maintainerr, mylar3, profilarr, valheim, watchstate,
+      # spierscraper, seerr, …) are covered transitively by the
+      # wholesale `/var/lib/containers` entry in preservation-server.nix
+      # and don't appear here. Stateless natives (miniflux — backed by
+      # postgres, no local state) are also omitted.
+      #
+      # Issue #136 was exactly this class of bug: 5 native arrs / readeck
+      # shipped on hpp-1 with impermanence enabled and no preservation
+      # entries; only the lack of a reboot between deploy and the audit
+      # kept it from silently wiping arr history. The assertion below
+      # makes the check structural rather than human-memory.
+      #
+      # When you add a new native app with persistent state:
+      #   1. Add a `preservation.preserveAt."/persist".directories`
+      #      entry in that app's module (see modules/apps/bazarr.nix for
+      #      the canonical pattern).
+      #   2. Append the on-disk state-dir path to the list below.
+      #
+      # NOTE: Paths are the public /var/lib/<app>, not the DynamicUser
+      # /var/lib/private/<app>. The exception is authentik, whose
+      # preservation entry intentionally targets the private dir (see
+      # modules/apps/authentik.nix for the why).
+      #
+      # NOTE: The check is hardcoded rather than fully generic because
+      # nix doesn't expose a uniform "this service has a StateDirectory"
+      # handle: modules variously use systemd `StateDirectory=`,
+      # `services.<app>.dataDir`, `services.<app>.stateDir`, or
+      # DynamicUser symlinks under /var/lib/private. Walking the
+      # systemd unit table for `StateDirectory=` would catch most but
+      # miss the dataDir/stateDir overrides — the hardcoded list keeps
+      # the assertion simple and unambiguous at the cost of needing one
+      # list update per new native app.
+      expectedPreservedDirs = [
+        "/var/lib/audiobookshelf"
+        "/var/lib/bazarr"
+        "/var/lib/jellyfin"
+        "/var/lib/kavita"
+        "/var/lib/komga"
+        "/var/lib/mealie"
+        "/var/lib/paperless-ngx"
+        "/var/lib/private/authentik"
+        "/var/lib/prowlarr"
+        "/var/lib/radarr"
+        "/var/lib/readeck"
+        "/var/lib/sabnzbd"
+        "/var/lib/sonarr"
+        # Container app whose volumes live OUTSIDE /var/lib/containers:
+        # the upstream unifi-os-server flake module defaults its
+        # `stateDir` to /var/lib/unifi-os-server.
+        "/var/lib/unifi-os-server"
+      ];
+
+      preservedDirs = map (d: d.directory) (config.preservation.preserveAt."/persist".directories or [ ]);
+
+      missing = lib.subtractLists preservedDirs expectedPreservedDirs;
+    in
+    {
+      imports = with inputs.self.modules.nixos; [
+        actualbudget
+        audiobookshelf
+        bazarr
+        grimmory
+        homeassistant
+        jellyfin
+        kapowarr
+        kavita
+        komga
+        maintainerr
+        mealie
+        miniflux
+        mylar3
+        paperless-ngx
+        profilarr
+        prowlarr
+        radarr
+        readeck
+        readmeabook
+        sabnzbd
+        seerr
+        shelfarr
+        sonarr
+        spierscraper
+        tandoor
+        unifi
+        valheim
+        watchstate
+      ];
+
+      assertions = [
+        {
+          # Only enforce when preservation is actually live on this
+          # host; non-impermanence hosts have nothing to preserve.
+          assertion = !config.preservation.enable || missing == [ ];
+          message = ''
+            server-apps: the following app state directories are
+            missing a `preservation.preserveAt."/persist".directories`
+            entry, and would be wiped on the next reboot under
+            impermanence:
+
+              ${lib.concatStringsSep "\n  " missing}
+
+            Add an entry in the owning app module (see e.g.
+            modules/apps/bazarr.nix for the pattern) and update
+            `expectedPreservedDirs` in modules/profiles/server-apps.nix.
+          '';
+        }
+      ];
+    };
 }


### PR DESCRIPTION
## Summary
- Close the remaining preservation gap: add an explicit `preservation.preserveAt."/persist".directories` entry for unifi (`/var/lib/unifi-os-server` — the upstream `rcambrj/unifi-os-server` flake module defaults `stateDir` there, NOT under `/var/lib/containers/`).
- Add a structural assertion in `modules/profiles/server-apps.nix` that fails evaluation if any native server-app with persistent state is missing a paired preservation entry. The check is hardcoded (nix doesn't expose a uniform `StateDirectory` handle across `StateDirectory=`, `services.<app>.dataDir`, `services.<app>.stateDir`, and DynamicUser symlinks) and gated by `config.preservation.enable` so non-impermanence hosts (e.g. ash-1) don't trip it.
- Audit confirms the 5 named native apps (bazarr, prowlarr, radarr, sonarr, readeck) already had preservation entries added in `8a9a1f1` (preservation-owner-mismatch fix). Sabnzbd, jellyfin, kavita, komga, audiobookshelf, mealie, paperless-ngx, authentik also covered. Container-only apps (kapowarr, maintainerr, mylar3, profilarr, valheim, watchstate, spierscraper, seerr, …) write under `/var/lib/containers/<app>` which is preserved wholesale. Miniflux is intentionally omitted — postgres-backed, no local state.

## Why hardcoded?
The assertion enumerates state-dir paths instead of walking systemd's `StateDirectory=` because modules variously override the data path via module-specific options (`services.<app>.dataDir`, `services.<app>.stateDir`) or store under `/var/lib/private/<app>` for DynamicUser. A purely-`StateDirectory`-driven check would catch most but miss those overrides. Cost: one list update per new native app. Benefit: silent data loss on next reboot becomes an eval-time failure. The comment block above the list documents this and points at `modules/apps/bazarr.nix` as the canonical pattern.

## Test plan
- [x] `nixfmt --check` clean
- [x] `task lint` (statix + deadnix) clean
- [x] `nix flake check --all-systems` clean — all hosts evaluate
- [x] `nix eval .#nixosConfigurations.hpp-1.config.system.build.toplevel.outPath` succeeds with `preservation.enable = true`
- [x] Manually verified that removing one of the entries from `expectedPreservedDirs`-vs-preservation-entries pairing produces the expected assertion failure on hpp-1's eval

## Left to validate
- [ ] After deploy to hpp-1, confirm `/persist/var/lib/unifi-os-server/` populates with the UniFi controller's mongodb/data/srv/log subtrees on first boot.
- [ ] Controlled reboot of hpp-1 retains: arr history (sonarr/radarr), parsing rules + indexers (prowlarr), subtitle queue (bazarr), bookmarks (readeck), UniFi controller adoption state.
- [ ] Confirm the assertion fires correctly if a new native app is added without updating both halves (drop a preservation entry from a current app on a feature branch, eval should fail with the expected message).

This pull request and its description were written by Isaac.