### PR TITLE
add healthchecks heartbeat to backup units — closes #138

### DIFF
--- a/modules/system/server-backups.nix
+++ b/modules/system/server-backups.nix
@@ -16,7 +16,22 @@
 # `mySqliteQuiesce` (modules/platform/sqlite-quiesce.nix) is imported
 # here so SQLite-backed app modules can opt into a pre-restic
 # `.backup` oneshot wherever this profile is in effect.
+#
+# Healthchecks.io liveness — closes #138. Prometheus rules catch units
+# that *failed*, but a timer that never fired (masked dep, disabled
+# unit, etc.) leaves no `state="failed"` sample to alert on. Each
+# backup unit therefore ExecStartPost-curls a per-job healthchecks.io
+# heartbeat URL on success. If the daily ping misses its window
+# healthchecks.io pages via the existing Discord integration —
+# mirroring the Alertmanager Watchdog pattern.
+#
+# ExecStartPost is only invoked when ExecStart exits 0 on a Type=oneshot
+# unit, so a failing backup deliberately does *not* ping. The dead-man's
+# switch is the missing ping, not an explicit /fail call.
 { inputs, ... }:
+let
+  sopsFolder = (builtins.toString inputs.nix-secrets) + "/sops";
+in
 {
   flake.modules.nixos.server-backups =
     {
@@ -25,6 +40,15 @@
       pkgs,
       ...
     }:
+    let
+      # Heartbeat helper. curl flags: fail on HTTP errors, silent w/
+      # body suppressed, hard 10s cap, retry transient network/5xx
+      # blips. systemd expands $HEALTHCHECK_URL from the unit's
+      # EnvironmentFile=; no shell involved, so the env var sits at
+      # argv[N] verbatim — exactly one argument, no word-splitting.
+      # Healthchecks.io accepts a bare GET as a successful ping.
+      heartbeatCmd = "${pkgs.curl}/bin/curl -fsS -m 10 --retry 5 -o /dev/null $HEALTHCHECK_URL";
+    in
     {
       imports = [ inputs.self.modules.nixos.mySqliteQuiesce ];
 
@@ -32,7 +56,49 @@
       # (e.g. cross-host recovery from /mnt/<env>-backups/restic/<host>).
       environment.systemPackages = [ pkgs.restic ];
 
-      sops.secrets."restic/password" = { };
+      sops.secrets = {
+        "restic/password" = { };
+        # Three per-job heartbeat URLs. Per-host sops file because the
+        # restic repo is also per-host, and each backup unit needs its
+        # own healthchecks.io check (otherwise one job silently masks
+        # another's miss).
+        "healthchecks/restic_backup_url" = {
+          sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
+          restartUnits = [ "restic-backups-server.service" ];
+        };
+        "healthchecks/postgresql_backup_url" = {
+          sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
+          restartUnits = [ "postgresqlBackup.service" ];
+        };
+        "healthchecks/mysql_backup_url" = {
+          sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
+          restartUnits = [ "mysql-backup.service" ];
+        };
+      };
+
+      # One env-file template per unit so each unit only sees its own
+      # URL (defence-in-depth — a buggy ExecStartPost can't accidentally
+      # ping the wrong check).
+      sops.templates = {
+        "restic-heartbeat.env" = {
+          content = ''
+            HEALTHCHECK_URL=${config.sops.placeholder."healthchecks/restic_backup_url"}
+          '';
+          restartUnits = [ "restic-backups-server.service" ];
+        };
+        "postgresql-backup-heartbeat.env" = {
+          content = ''
+            HEALTHCHECK_URL=${config.sops.placeholder."healthchecks/postgresql_backup_url"}
+          '';
+          restartUnits = [ "postgresqlBackup.service" ];
+        };
+        "mysql-backup-heartbeat.env" = {
+          content = ''
+            HEALTHCHECK_URL=${config.sops.placeholder."healthchecks/mysql_backup_url"}
+          '';
+          restartUnits = [ "mysql-backup.service" ];
+        };
+      };
 
       services = {
         postgresqlBackup = {
@@ -81,15 +147,33 @@
         };
       };
 
-      # Restic timer fires after the database dumps so each daily snapshot
-      # contains the morning's dumps from both engines.
-      systemd.services.restic-backups-server = {
-        after = [
-          "mnt-backups.mount"
-          "postgresqlBackup.service"
-          "mysql-backup.service"
-        ];
-        requires = [ "mnt-backups.mount" ];
+      systemd.services = {
+        # Restic timer fires after the database dumps so each daily
+        # snapshot contains the morning's dumps from both engines.
+        # ExecStartPost runs only on successful ExecStart, giving us
+        # the "last successful snapshot" liveness the issue asks for.
+        restic-backups-server = {
+          after = [
+            "mnt-backups.mount"
+            "postgresqlBackup.service"
+            "mysql-backup.service"
+          ];
+          requires = [ "mnt-backups.mount" ];
+          serviceConfig = {
+            EnvironmentFile = [ config.sops.templates."restic-heartbeat.env".path ];
+            ExecStartPost = [ heartbeatCmd ];
+          };
+        };
+
+        postgresqlBackup.serviceConfig = {
+          EnvironmentFile = [ config.sops.templates."postgresql-backup-heartbeat.env".path ];
+          ExecStartPost = [ heartbeatCmd ];
+        };
+
+        mysql-backup.serviceConfig = {
+          EnvironmentFile = [ config.sops.templates."mysql-backup-heartbeat.env".path ];
+          ExecStartPost = [ heartbeatCmd ];
+        };
       };
     };
 }


### PR DESCRIPTION
## Summary
- `postgresqlBackup.service`, `mysql-backup.service`, and `restic-backups-server.service` now ExecStartPost-curl a per-job healthchecks.io URL on success.
- Missing ping is the dead-man's switch — catches the gap that `node_systemd_unit_state{state="failed"}` can't (timers that never fire, masked units, etc.).
- Mirrors the existing Alertmanager Watchdog -> healthchecks.io pattern; alerts land in the same Discord channel via healthchecks.io's existing integration.

## Implementation notes
- `ExecStartPost=` only runs after a successful `ExecStart=` on `Type=oneshot` units, so a *failed* backup deliberately doesn't ping. No need for an explicit `/fail` call — the absent heartbeat is the signal.
- Three new sops secrets: `healthchecks/restic_backup_url`, `healthchecks/postgresql_backup_url`, `healthchecks/mysql_backup_url` (per-host `<hostname>.yaml`, since the restic repo is also per-host).
- Each unit gets its own sops template + `EnvironmentFile=` so a buggy `ExecStartPost` can't accidentally ping the wrong check.

## Left to validate (operator)
This won't actually emit heartbeats until the operator does the following on each server host:

1. Create three healthchecks.io checks (one per backup job), set Grace + Period to ~36h to match the daily cadence.
2. Add the three ping URLs to `nix-secrets/sops/<hostname>.yaml` under these keys:
   - `healthchecks/restic_backup_url`
   - `healthchecks/postgresql_backup_url`
   - `healthchecks/mysql_backup_url`
3. `task deploy:<host>` — sops will materialize the env files and restart the affected units.
4. Force a manual run (`systemctl start postgresqlBackup.service` etc.) and confirm healthchecks.io shows a successful ping for each.

## Test plan
- [ ] `nix flake check --all-systems` passes (verified locally — see commit)
- [ ] After secrets are added + deploy, manual `systemctl start postgresqlBackup.service` produces a green ping on the corresponding healthchecks.io check
- [ ] Same for `mysql-backup.service` and `restic-backups-server.service`
- [ ] Stop the timer for one job for >36h and confirm healthchecks.io alerts via Discord

This pull request and its description were written by Isaac.