### PR TITLE
assert serverDomain + serverEnvironment on server profile — closes #151

### DIFF
--- a/modules/profiles/server.nix
+++ b/modules/profiles/server.nix
@@ -6,34 +6,68 @@
 #
 # This is a flake-parts module that registers:
 # - flake.modules.nixos.server (NixOS server config)
+#
+# Top-level assertions enforce the server-tier hostSpec contract:
+# `serverDomain` and `serverEnvironment` are typed as `nullOr ...` in
+# `hostSpecs/host-spec.nix` so workstation hosts can leave them unset,
+# but every consumer of those fields under this profile (caddy,
+# authentik, server-users, nfsclient, …) reads them unguarded. The
+# fail-fast check lives here so importing `server` on a host that
+# forgot to populate the fields surfaces one clear error at evaluation
+# time instead of producing literal `"foo.null"` hostnames downstream.
 { inputs, ... }:
 {
-  flake.modules.nixos.server = _: {
-    imports = with inputs.self.modules.nixos; [
-      apprise
-      auto-rebuild
-      authentik
-      base
-      caddy
-      gatus
-      homepage
-      mariadb
-      nfsclient
-      nix-maintenance
-      observability
-      oci-containers
-      postgresql
-      preservation-server
-      server-backups
-      server-users
-      sops
-      ssh
-      tailscale
-    ];
+  flake.modules.nixos.server =
+    { hostSpec, ... }:
+    {
+      imports = with inputs.self.modules.nixos; [
+        apprise
+        auto-rebuild
+        authentik
+        base
+        caddy
+        gatus
+        homepage
+        mariadb
+        nfsclient
+        nix-maintenance
+        observability
+        oci-containers
+        postgresql
+        preservation-server
+        server-backups
+        server-users
+        sops
+        ssh
+        tailscale
+      ];
 
-    # Home-manager modules common to all servers
-    home-manager.sharedModules = with inputs.self.modules.homeManager; [
-      core
-    ];
-  };
+      assertions = [
+        {
+          assertion = hostSpec.serverEnvironment != null;
+          message = ''
+            The `server` profile requires `hostSpec.serverEnvironment` to be
+            set ("dev" or "prod"). Host "${hostSpec.hostName}" leaves it
+            null — populate it in hostSpecs/${hostSpec.hostName}.nix or
+            drop the `server` profile from this host's modules.
+          '';
+        }
+        {
+          assertion = hostSpec.serverDomain != null;
+          message = ''
+            The `server` profile requires `hostSpec.serverDomain` to be set
+            (e.g. "dnix.ipreston.net"). Host "${hostSpec.hostName}" leaves
+            it null — caddy and authentik consumers would emit literal
+            "<app>.null" hostnames. Populate it in
+            hostSpecs/${hostSpec.hostName}.nix or drop the `server`
+            profile from this host's modules.
+          '';
+        }
+      ];
+
+      # Home-manager modules common to all servers
+      home-manager.sharedModules = with inputs.self.modules.homeManager; [
+        core
+      ];
+    };
 }

--- a/modules/system/nfsclient.nix
+++ b/modules/system/nfsclient.nix
@@ -5,6 +5,12 @@
 # /mnt/<otherEnv>-content / /mnt/<otherEnv>-backups for migrations or
 # copies. UID/GID-based access control on the NAS (server-dev 1029,
 # server-prod 1030, group servers 65536) decides who can actually write.
+#
+# TODO #151: the dev/prod environment set is duplicated between this
+# module (contentByEnv / backupsByEnv) and server-users.nix (uidByEnv).
+# Consolidate the per-environment metadata in one place so adding a
+# third environment is a one-file change. See issue #151 for the
+# broader assertion-layer cleanup this rides alongside.
 _: {
   flake.modules.nixos.nfsclient =
     { hostSpec, ... }:

--- a/modules/system/server-users.nix
+++ b/modules/system/server-users.nix
@@ -7,6 +7,13 @@
 #   group servers   = 65536
 #   user  server-dev  = 1029
 #   user  server-prod = 1030
+#
+# TODO #151: the `uidByEnv` table here and the NFS share tables in
+# nfsclient.nix both hard-code the dev/prod environment set.
+# Consolidate into one `attrsOf int` table (likely derived onto
+# hostSpec as `serverUid`) so adding a third environment (e.g. staging)
+# is a one-file change. Not required for the fail-fast assertion layer
+# that is the primary goal of issue #151.
 { lib, ... }:
 {
   flake.modules.nixos.server-users =


### PR DESCRIPTION
## Summary
- Added top-level `assertions` in `modules/profiles/server.nix` that fail evaluation if `hostSpec.serverDomain` or `hostSpec.serverEnvironment` is null while the `server` profile is imported. Error messages name the offending host and suggest the fix.
- Workstation hosts can still leave the fields null — the `nullOr` type in `hostSpecs/host-spec.nix` is unchanged; only consumers under the `server` profile need the guard.
- Issue's bonus item (consolidate dev/prod UID tables into a single `attrsOf int` derived onto hostSpec) is **deferred with TODO #151 markers** in `nfsclient.nix` + `server-users.nix`. That cleanup is orthogonal to the fail-fast assertion goal and adds churn without immediate payoff.

## Validation performed
- Agent finished implementation cleanly. `nix flake check --all-systems` was running when its 600s watchdog tripped; salvaged staged work, committed, pushed.

## Left to validate
- `nix flake check --all-systems` on this branch in isolation (CI workflow from PR #159 will catch eval regressions).
- Negative test: temporarily null out `hpp-1.nix`'s `serverDomain` and confirm eval fails with the expected message (do not commit).

Closes #151

PR salvaged from a stalled subagent worktree by Claude.