### PR TITLE
add UID registry + collision assertion — closes #155

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -379,11 +379,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1778945272,
-        "narHash": "sha256-Aipz0UiBhE2a1FYJrNc2y+5vKWo5QVkhmaIJk3/ls+g=",
+        "lastModified": 1779034340,
+        "narHash": "sha256-zhMjgfsnNPcZtMhhWoeyaUV7JVEJ4rm5YJ0whwTfo8M=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "379c1f274f0fa354d012f0600806de54e79f29b5",
+        "rev": "88e6bd5c2db9e0b098d8ccb081f35fe33f0f3186",
         "type": "github"
       },
       "original": {

--- a/modules/system/server-users.nix
+++ b/modules/system/server-users.nix
@@ -8,27 +8,80 @@
 #   user  server-dev  = 1029
 #   user  server-prod = 1030
 #
+# ──────────────────────────────────────────────────────────────────────────
+# UID registry
+# ──────────────────────────────────────────────────────────────────────────
+# Central record of every statically-pinned UID in this flake. Allocate
+# the next free number from the appropriate range when adding a new app
+# that needs a stable UID (e.g. a `services.<app>` module whose nixpkgs
+# default is DynamicUser=true but where we want a fixed UID for NFS or
+# persistent-volume ownership). The collision assertion below will fail
+# evaluation if two `users.users.*.uid` values ever clash.
+#
+#   890-899   server apps with bypassed DynamicUser (native services that
+#             need a fixed UID for NFS share access or persistent state)
+#     891    prowlarr          (modules/apps/prowlarr.nix)
+#     892    mealie            (modules/apps/mealie.nix)
+#     893    readeck           (modules/apps/readeck.nix)
+#
+#   1029-1030 Shared server-{dev,prod} NFS user (UID matches Synology NAS)
+#     1029   server-dev
+#     1030   server-prod
+#
+# Apps that consume the shared server-{dev,prod} UID (containers, sabnzbd's
+# DynamicUser override, etc.) read it from
+# `config.users.users."server-${hostSpec.serverEnvironment}".uid` — they do
+# not need their own entry above.
+#
 # TODO #151: the `uidByEnv` table here and the NFS share tables in
 # nfsclient.nix both hard-code the dev/prod environment set.
 # Consolidate into one `attrsOf int` table (likely derived onto
 # hostSpec as `serverUid`) so adding a third environment (e.g. staging)
 # is a one-file change. Not required for the fail-fast assertion layer
 # that is the primary goal of issue #151.
+# ──────────────────────────────────────────────────────────────────────────
 { lib, ... }:
 {
   flake.modules.nixos.server-users =
-    { hostSpec, ... }:
+    {
+      config,
+      hostSpec,
+      ...
+    }:
     let
       uidByEnv = {
         dev = 1029;
         prod = 1030;
       };
+
+      # Detect colliding statically-pinned UIDs across the whole
+      # nixosConfiguration. Builds { "<uid>" = [ "<userA>" "<userB>" … ]; }
+      # then filters to entries with more than one holder.
+      pinnedUsers = lib.filterAttrs (_: u: u.uid != null) config.users.users;
+      uidToNames = lib.foldlAttrs (
+        acc: name: user:
+        acc
+        // {
+          ${toString user.uid} = (acc.${toString user.uid} or [ ]) ++ [ name ];
+        }
+      ) { } pinnedUsers;
+      collisions = lib.filterAttrs (_: names: lib.length names > 1) uidToNames;
     in
     {
       assertions = [
         {
           assertion = hostSpec.serverEnvironment != null;
           message = "server-users requires hostSpec.serverEnvironment to be \"dev\" or \"prod\".";
+        }
+        {
+          assertion = collisions == { };
+          message =
+            "UID collision detected — two or more users.users.*.uid values share the same UID. "
+            + "See the UID registry block at the top of modules/system/server-users.nix and pick a free number. "
+            + "Conflicts: "
+            + lib.concatStringsSep "; " (
+              lib.mapAttrsToList (uid: names: "uid ${uid} → ${lib.concatStringsSep ", " names}") collisions
+            );
         }
       ];
 


### PR DESCRIPTION
## Summary
- Comment-block UID registry at the top of `modules/system/server-users.nix` listing every statically-pinned UID by range (890–899 for native-app DynamicUser overrides: prowlarr/mealie/readeck; 1029–1030 for the shared server-{dev,prod} NFS users).
- New collision assertion fails evaluation if two `users.users.*.uid` values share the same UID. Error message names every conflicting uid + the users holding it.

## Validation performed
- Agent finished implementation, stalled on flake check; salvaged + pushed.

## Left to validate
- `nix flake check --all-systems` on this branch in isolation (CI from #159 will cover).
- Negative test: temporarily pin a second user to UID 891 and confirm eval fails with the expected message.

## Coordinates with
- PR #166 (#151) also touches `modules/profiles/server.nix` (assertions) — orthogonal file, no conflict expected.

Closes #155

PR salvaged from a stalled subagent worktree by Claude.