### PR TITLE
bump loki retention to 30d + narrow node_exporter systemd collector — closes #157

### DIFF
--- a/modules/system/loki.nix
+++ b/modules/system/loki.nix
@@ -59,10 +59,15 @@ _: {
             delete_request_store = "filesystem";
           };
           limits_config = {
-            retention_period = "168h"; # 7d
+            # 30d gives enough history to catch slow-burn issues (gradual
+            # OOM creep, weekly cron failures, certificate-near-expiry
+            # warnings) while staying well within the host's free space.
+            # Bumped from 7d per #157; revisit if /var/lib/loki growth
+            # becomes a problem.
+            retention_period = "720h"; # 30d
             allow_structured_metadata = true;
             reject_old_samples = true;
-            reject_old_samples_max_age = "168h";
+            reject_old_samples_max_age = "720h";
           };
           analytics.reporting_enabled = false;
         };

--- a/modules/system/observability.nix
+++ b/modules/system/observability.nix
@@ -10,7 +10,7 @@
 # Stack:
 #   Prometheus     — scrapes node/postgres/mysqld/redis/caddy/cadvisor/
 #                    itself; ephemeral on-disk TSDB with 15d retention.
-#   Loki           — single-node, filesystem store; ~7d retention.
+#   Loki           — single-node, filesystem store; ~30d retention.
 #   Promtail       — ships the systemd journal into Loki.
 #   Grafana        — dashboards + provisioned datasources, OIDC against
 #                    Authentik via myAuthentik.oidcApps.

--- a/modules/system/prometheus.nix
+++ b/modules/system/prometheus.nix
@@ -82,6 +82,50 @@ _: {
                 "systemd"
                 "processes"
               ];
+              # Narrow the systemd collector to units we actually
+              # dashboard/alert on. Without this, node_systemd_unit_state
+              # emits a series per (unit × state) for every unit on the
+              # host — hundreds of mounts, scopes, user@*.service slices,
+              # podman-internal helpers — which blows up TSDB cardinality
+              # for no observability gain.
+              #
+              # Per #157: re-evaluate this regex when adding a new app
+              # module. Anything not matched here is invisible to
+              # SystemdUnitFailed alerting.
+              extraFlags = [
+                (
+                  "--collector.systemd.unit-include=^("
+                  # Core infra:
+                  #   sshd       — remote access; if it dies we're cooked.
+                  #   caddy      — TLS edge / reverse proxy for everything.
+                  #   postgresql — shared DB for most apps.
+                  #   mysql      — shared MariaDB (grimmory, etc.).
+                  #   redis*     — unnamed instance + named per-app servers
+                  #                (paperless, …) get redis-<name>.service.
+                  #   restic-backups-server — nightly off-site backup.
+                  + "sshd|caddy|postgresql|mysql|redis(-.+)?|restic-backups-server"
+                  # Authentik (SSO) — server + worker + migrate one-shot.
+                  + "|authentik(-worker|-migrate)?"
+                  # Observability stack itself — useful to know if our
+                  # own scrapers fall over.
+                  + "|prometheus|alertmanager|grafana|loki|promtail|cadvisor|gatus"
+                  + "|prometheus-(node|postgres|mysqld|redis)-exporter"
+                  # Native NixOS app services (modules/apps/*.nix using
+                  # services.<app>): audiobookshelf, bazarr, jellyfin,
+                  # kavita, komga, mealie, miniflux, paperless (multi-unit:
+                  # web/scheduler/task-queue/consumer), prowlarr, radarr,
+                  # readeck, sabnzbd, sonarr, spierscraper, unifi-os-server.
+                  + "|audiobookshelf|bazarr|jellyfin|kavita|komga|mealie|miniflux"
+                  + "|paperless(-.+)?|prowlarr|radarr|readeck|sabnzbd|sonarr"
+                  + "|spierscraper|unifi-os-server"
+                  # Container-based apps (modules/apps/*.nix using
+                  # virtualisation.oci-containers): each registers a
+                  # podman-<name>.service unit.
+                  + "|podman-(actualbudget|grimmory|homeassistant|kapowarr"
+                  + "|maintainerr|mylar3|profilarr|readmeabook|seerr|shelfarr"
+                  + "|tandoor|valheim|watchstate))\\.service$"
+                )
+              ];
             };
             postgres = {
               enable = true;


### PR DESCRIPTION
## Summary
- **Loki**: `retention_period` and `reject_old_samples_max_age` 7d → 30d.
- **node_exporter**: `--collector.systemd.unit-include` regex allowlists units worth dashboarding/alerting on:
  - Core infra: sshd, caddy, postgresql, mysql, redis(-*), restic-backups-server
  - Authentik + observability stack itself
  - Every native NixOS app module (audiobookshelf/bazarr/jellyfin/kavita/komga/mealie/miniflux/paperless-*/prowlarr/radarr/readeck/sabnzbd/sonarr/spierscraper/unifi-os-server)
  - Containerized apps' `podman-<name>.service` units

## Validation performed
- Agent committed clean diff to one file; stalled on flake check; salvaged + pushed.

## Left to validate
- `nix flake check --all-systems` on this branch in isolation.
- After deploy: confirm `/var/lib/loki` size is bounded by the new 30d window (Loki compaction lazy-prunes).
- Confirm `node_systemd_unit_state` cardinality drops noticeably in Prometheus.
- Re-evaluate the unit-include regex whenever a new app module lands — anything outside the regex is invisible to `SystemdUnitFailed` alerting.

## Coordinates with
- PR #162 (#139) splits `observability.nix` into per-service modules. Merge conflict on `observability.nix` likely — the hunks here move into `loki.nix` and `prometheus.nix` respectively.

Closes #157

PR salvaged from a stalled subagent worktree by Claude.