### PR TITLE
coerce appRestartUnit + consumerService to listOf str — closes #153

### DIFF
--- a/modules/apps/actualbudget.nix
+++ b/modules/apps/actualbudget.nix
@@ -20,7 +20,7 @@ _: {
     {
       myAuthentik.oidcApps.actualbudget = {
         blueprintsDir = ./actualbudget-blueprints;
-        appRestartUnit = "podman-actualbudget.service";
+        appRestartUnit = [ "podman-actualbudget.service" ];
         clientIdVar = "ACTUAL_OPENID_CLIENT_ID";
         clientSecretVar = "ACTUAL_OPENID_CLIENT_SECRET";
         homepage = {

--- a/modules/apps/grimmory.nix
+++ b/modules/apps/grimmory.nix
@@ -32,7 +32,7 @@ _: {
     {
       myAuthentik.oidcApps.grimmory = {
         blueprintsDir = ./grimmory-blueprints;
-        appRestartUnit = "podman-grimmory.service";
+        appRestartUnit = [ "podman-grimmory.service" ];
         publicClient = true;
         clientCredsInAppEnv = false;
         displayName = "Grimmory";

--- a/modules/apps/grimmory.nix
+++ b/modules/apps/grimmory.nix
@@ -41,7 +41,7 @@ _: {
         '';
         extraSecrets = {
           "grimmory/db_password" = {
-            sopsFile = hostSpec.sopsFile;
+            inherit (hostSpec) sopsFile;
             owner = "mysql";
             restartUnits = [
               "grimmory-db-password.service"

--- a/modules/apps/komga.nix
+++ b/modules/apps/komga.nix
@@ -24,7 +24,7 @@ _: {
     {
       myAuthentik.oidcApps.komga = {
         blueprintsDir = ./komga-blueprints;
-        appRestartUnit = "komga.service";
+        appRestartUnit = [ "komga.service" ];
         clientIdVar = "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AUTHENTIK_CLIENT_ID";
         clientSecretVar = "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AUTHENTIK_CLIENT_SECRET";
         homepage = {

--- a/modules/apps/manyfold.nix
+++ b/modules/apps/manyfold.nix
@@ -46,7 +46,7 @@ in
       redisPort = 6380;
     in
     {
-      myPostgresApp.manyfold.consumerService = "podman-manyfold.service";
+      myPostgresApp.manyfold.consumerService = [ "podman-manyfold.service" ];
 
       myAuthentik.forwardAuthApps.manyfold = {
         inherit port;

--- a/modules/apps/mealie.nix
+++ b/modules/apps/mealie.nix
@@ -34,7 +34,7 @@ _: {
     {
       myAuthentik.oidcApps.mealie = {
         blueprintsDir = ./mealie-blueprints;
-        appRestartUnit = "mealie.service";
+        appRestartUnit = [ "mealie.service" ];
         homepage = {
           group = "Home";
           icon = "mealie";

--- a/modules/apps/miniflux.nix
+++ b/modules/apps/miniflux.nix
@@ -28,7 +28,7 @@ _: {
     {
       myAuthentik.oidcApps.miniflux = {
         blueprintsDir = ./miniflux-blueprints;
-        appRestartUnit = "miniflux.service";
+        appRestartUnit = [ "miniflux.service" ];
         clientIdVar = "OAUTH2_CLIENT_ID";
         clientSecretVar = "OAUTH2_CLIENT_SECRET";
         homepage = {

--- a/modules/apps/paperless-ngx.nix
+++ b/modules/apps/paperless-ngx.nix
@@ -43,7 +43,7 @@ _: {
       myPostgresApp.paperless-ngx.consumerService = paperlessUnits;
 
       sops.secrets."paperless-ngx/secret_key" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
         restartUnits = paperlessUnits;
       };
 

--- a/modules/apps/paperless-ngx.nix
+++ b/modules/apps/paperless-ngx.nix
@@ -40,7 +40,7 @@ _: {
       ];
     in
     {
-      myPostgresApp.paperless-ngx.consumerService = "paperless-scheduler.service";
+      myPostgresApp.paperless-ngx.consumerService = paperlessUnits;
 
       sops.secrets."paperless-ngx/secret_key" = {
         sopsFile = hostSpec.sopsFile;

--- a/modules/apps/readeck.nix
+++ b/modules/apps/readeck.nix
@@ -36,7 +36,7 @@ _: {
     in
     {
       sops.secrets."readeck/secret_key" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
         restartUnits = [ "readeck.service" ];
       };
 

--- a/modules/apps/spierscraper.nix
+++ b/modules/apps/spierscraper.nix
@@ -47,7 +47,7 @@ _: {
     in
     {
       sops.secrets."discord/spierscraper_webhook" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
       };
 
       sops.templates."spierscraper.env" = {

--- a/modules/apps/tandoor.nix
+++ b/modules/apps/tandoor.nix
@@ -32,7 +32,7 @@ _: {
       myPostgresApp.tandoor.consumerService = [ "podman-tandoor.service" ];
 
       sops.secrets."tandoor/secret_key" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
         restartUnits = [ "podman-tandoor.service" ];
       };
 

--- a/modules/apps/tandoor.nix
+++ b/modules/apps/tandoor.nix
@@ -29,7 +29,7 @@ _: {
       authentikHost = "authentik.${hostSpec.serverDomain}";
     in
     {
-      myPostgresApp.tandoor.consumerService = "podman-tandoor.service";
+      myPostgresApp.tandoor.consumerService = [ "podman-tandoor.service" ];
 
       sops.secrets."tandoor/secret_key" = {
         sopsFile = hostSpec.sopsFile;
@@ -38,7 +38,7 @@ _: {
 
       myAuthentik.oidcApps.tandoor = {
         blueprintsDir = ./tandoor-blueprints;
-        appRestartUnit = "podman-tandoor.service";
+        appRestartUnit = [ "podman-tandoor.service" ];
         clientCredsInAppEnv = false;
         displayName = "Tandoor";
         extraEnvLines = ''

--- a/modules/apps/valheim.nix
+++ b/modules/apps/valheim.nix
@@ -44,7 +44,7 @@ _: {
     in
     {
       sops.secrets."valheim/server_password" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
         restartUnits = [ "podman-valheim.service" ];
       };
 

--- a/modules/platform/authentik.nix
+++ b/modules/platform/authentik.nix
@@ -139,24 +139,12 @@ in
         };
       });
 
-      # appRestartUnit is `nullOr (either str (listOf str))` — normalize
-      # it to a plain list so consumers don't have to special-case the
-      # scalar form.
-      appRestartUnits =
-        app:
-        if app.appRestartUnit == null then
-          [ ]
-        else if lib.isList app.appRestartUnit then
-          app.appRestartUnit
-        else
-          [ app.appRestartUnit ];
-
       # Restart units for an app's OIDC sops secret. Always bounces
       # authentik (so the worker sees the new placeholder when the
       # blueprint is re-applied); also bounces the app's own service
       # iff the app reads creds from its env file.
       oidcSecretRestartUnits =
-        app: restartAuthentik ++ lib.optionals app.clientCredsInAppEnv (appRestartUnits app);
+        app: restartAuthentik ++ lib.optionals app.clientCredsInAppEnv app.appRestartUnit;
 
       mkOidcSecret = _appName: app: {
         sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
@@ -309,18 +297,19 @@ in
                     '';
                   };
                   appRestartUnit = lib.mkOption {
-                    type = lib.types.nullOr (lib.types.either lib.types.str (lib.types.listOf lib.types.str));
-                    default = null;
+                    type = lib.types.listOf lib.types.str;
+                    default = [ ];
                     description = ''
-                      Systemd unit (or list of units) to restart when
-                      the per-app env file changes. Required when
+                      Systemd units to restart when the per-app env
+                      file changes. Required (non-empty) when
                       `clientCredsInAppEnv` is true or `extraEnvLines`
-                      is non-empty. Leave null for apps with no per-app
-                      env file (e.g. audiobookshelf, kavita, seerr —
-                      all DB/UI configured). Pass a list when an app
-                      ships multiple systemd units that all consume
-                      the env file (e.g. paperless-ngx with
-                      paperless-{web,scheduler,consumer,task-queue}).
+                      is non-empty. Leave as the empty default for
+                      apps with no per-app env file (e.g.
+                      audiobookshelf, kavita, seerr — all DB/UI
+                      configured). Pass every unit that consumes the
+                      env file (e.g. paperless-ngx with
+                      paperless-{web,scheduler,consumer,task-queue})
+                      so they all bounce on credential rotation.
                     '';
                   };
                   publicClient = lib.mkOption {
@@ -460,7 +449,7 @@ in
               appName: app:
               lib.nameValuePair app.envFileName {
                 content = oidcAppEnvContent appName app;
-                restartUnits = appRestartUnits app;
+                restartUnits = app.appRestartUnit;
               }
             ) oidcApps)
             //

--- a/modules/platform/postgres-app.nix
+++ b/modules/platform/postgres-app.nix
@@ -87,7 +87,7 @@ _: {
         sops.secrets = lib.mapAttrs' (
           name: app:
           lib.nameValuePair app.secretName {
-            sopsFile = hostSpec.sopsFile;
+            inherit (hostSpec) sopsFile;
             owner = "postgres";
             restartUnits = [ "${name}-db-password.service" ];
           }

--- a/modules/platform/postgres-app.nix
+++ b/modules/platform/postgres-app.nix
@@ -54,13 +54,18 @@ _: {
                   '';
                 };
                 consumerService = lib.mkOption {
-                  type = lib.types.str;
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
                   description = ''
-                    Systemd unit that consumes this role and must wait
+                    Systemd units that consume this role and must wait
                     for the password rotation oneshot to complete. The
                     oneshot is wired with `before` and `wantedBy` on
-                    this unit, so the consumer never starts with a
-                    stale password.
+                    every listed unit, so no consumer ever starts with
+                    a stale password. Pass every unit that opens a
+                    connection (e.g. paperless-ngx with
+                    paperless-{web,scheduler,task-queue,consumer})
+                    rather than trusting transitive ordering through a
+                    single representative unit.
                   '';
                 };
                 secretName = lib.mkOption {
@@ -121,8 +126,8 @@ _: {
               "postgresql-setup.service"
               "sops-install-secrets.service"
             ];
-            wantedBy = [ app.consumerService ];
-            before = [ app.consumerService ];
+            wantedBy = app.consumerService;
+            before = app.consumerService;
             # Skip the unit if sops hasn't decrypted *this specific*
             # secret yet (sops-install-secrets.service may report
             # success overall while a single entry failed — wrong age

--- a/modules/system/alertmanager.nix
+++ b/modules/system/alertmanager.nix
@@ -21,11 +21,11 @@ _: {
     {
       sops.secrets = {
         "discord/alerts_webhook" = {
-          sopsFile = hostSpec.sopsFile;
+          inherit (hostSpec) sopsFile;
           restartUnits = [ "alertmanager.service" ];
         };
         "alertmanager/heartbeat_url" = {
-          sopsFile = hostSpec.sopsFile;
+          inherit (hostSpec) sopsFile;
           restartUnits = [ "alertmanager.service" ];
         };
       };

--- a/modules/system/caddy.nix
+++ b/modules/system/caddy.nix
@@ -95,7 +95,7 @@ _: {
         };
 
         sops.secrets."cloudflare/acme_token" = {
-          sopsFile = hostSpec.sopsFile;
+          inherit (hostSpec) sopsFile;
           owner = "caddy";
           restartUnits = [ "caddy.service" ];
         };

--- a/modules/system/grafana.nix
+++ b/modules/system/grafana.nix
@@ -61,7 +61,7 @@ _: {
       # account password, read via $__file{} (no env). Owned by
       # grafana so the unit can read it.
       sops.secrets."grafana/bootstrap_password" = {
-        sopsFile = hostSpec.sopsFile;
+        inherit (hostSpec) sopsFile;
         owner = "grafana";
         restartUnits = [ "grafana.service" ];
       };


### PR DESCRIPTION
## Summary
- `myAuthentik.oidcApps.<name>.appRestartUnit`: `nullOr (either str (listOf str))` → `listOf str` (default `[]`). Drops the `appRestartUnits` normalization helper at the aggregator. Single-unit callers now pass `[ "foo.service" ]`; no-restart callers pass `[]` (vs `null`).
- `myPostgresApp.<name>.consumerService`: `str` → `listOf str` (default `[]`). Aggregator fans out `before` and `wantedBy` across every listed unit, so multi-unit apps (paperless-{web,scheduler,task-queue,consumer}) no longer trust transitive ordering through a single representative unit.
- Mechanically updated all callers in `modules/apps/*.nix` (actualbudget, grimmory, komga, mealie, miniflux, paperless-ngx, tandoor).

## Validation performed
- Agent finished implementation cleanly; stalled on flake check; salvaged + pushed.

## Left to validate
- `nix flake check --all-systems` on this branch in isolation.
- Live deploy to hpp-1 — confirm paperless workers all bounce on next sops rotation; postgres password rotation ordering still holds across multi-unit apps.

Closes #153

PR salvaged from a stalled subagent worktree by Claude.