### PR TITLE
add pinchflat + metube for yt-dlp downloads

### DIFF
--- a/modules/apps/metube.nix
+++ b/modules/apps/metube.nix
@@ -1,0 +1,68 @@
+# MeTube - single-page yt-dlp frontend for ad-hoc downloads
+# Container only — not packaged in nixpkgs (the closest names there
+# are unrelated apps: `metee`, `smtube`, `yewtube`). auth/caddy/
+# homepage wired by platform/authentik.nix. MeTube ships no built-in
+# auth, so forward-auth is mandatory in front of it.
+#
+# Downloads land in /mnt/content/youtube/metube so they're visible to
+# Jellyfin via the same NFS share pinchflat writes to (kept under a
+# sibling dir so the two tools don't fight over output templates).
+# Container runs as server-${env}:servers so NFS sees the expected
+# UID/GID. CHOWN_DIRS is disabled because the container would
+# otherwise try to chown the NFS mount on startup (the NAS rejects
+# server-side chowns from clients).
+_: {
+  flake.modules.nixos.metube =
+    {
+      config,
+      hostSpec,
+      ...
+    }:
+    let
+      serverUid = config.users.users."server-${hostSpec.serverEnvironment}".uid;
+      serverGid = config.users.groups.servers.gid;
+      port = 8081;
+    in
+    {
+      myAuthentik.forwardAuthApps.metube = {
+        inherit port;
+        displayName = "MeTube";
+        iconUrl = "https://raw.githubusercontent.com/alexta69/metube/master/favicon/android-chrome-192x192.png";
+        homepage = {
+          group = "Acquisition";
+          icon = "https://raw.githubusercontent.com/alexta69/metube/master/favicon/android-chrome-192x192.png";
+          description = "Ad-hoc yt-dlp downloader";
+        };
+      };
+
+      # State dir for MeTube's queue.json / completed.json etc. Kept
+      # off the NFS share so persistence survives independent of the
+      # media output dir.
+      systemd.tmpfiles.rules = [
+        "d /var/lib/containers/metube 0750 ${toString serverUid} ${toString serverGid} -"
+      ];
+
+      virtualisation.oci-containers.containers.metube = {
+        # renovate: datasource=docker depName=ghcr.io/alexta69/metube
+        image = "ghcr.io/alexta69/metube:2026.04.28";
+        ports = [ "127.0.0.1:${toString port}:${toString port}" ];
+        user = "${toString serverUid}:${toString serverGid}";
+        volumes = [
+          "/var/lib/containers/metube:/downloads/.metube"
+          "/mnt/content/youtube/metube:/downloads"
+        ];
+        environment = {
+          TZ = config.time.timeZone;
+          DOWNLOAD_DIR = "/downloads";
+          STATE_DIR = "/downloads/.metube";
+          TEMP_DIR = "/downloads";
+          # NFS rejects client-side chown; skip the startup ownership
+          # fixup since the bind-mount root is already owned correctly
+          # by the systemd-tmpfiles rule above and the NAS export.
+          CHOWN_DIRS = "false";
+          UID = toString serverUid;
+          GID = toString serverGid;
+        };
+      };
+    };
+}

--- a/modules/apps/metube.nix
+++ b/modules/apps/metube.nix
@@ -21,7 +21,10 @@ _: {
     let
       serverUid = config.users.users."server-${hostSpec.serverEnvironment}".uid;
       serverGid = config.users.groups.servers.gid;
-      port = 8081;
+      # 8081 is cAdvisor (modules/system/prometheus.nix); 8082 is
+      # homepage (modules/system/homepage.nix). 8085 is the next free
+      # loopback port.
+      port = 8085;
     in
     {
       myAuthentik.forwardAuthApps.metube = {
@@ -45,7 +48,9 @@ _: {
       virtualisation.oci-containers.containers.metube = {
         # renovate: datasource=docker depName=ghcr.io/alexta69/metube
         image = "ghcr.io/alexta69/metube:2026.04.28";
-        ports = [ "127.0.0.1:${toString port}:${toString port}" ];
+        # MeTube inside the container always listens on 8081; map our
+        # chosen host port onto that.
+        ports = [ "127.0.0.1:${toString port}:8081" ];
         user = "${toString serverUid}:${toString serverGid}";
         volumes = [
           "/var/lib/containers/metube:/downloads/.metube"

--- a/modules/apps/pinchflat.nix
+++ b/modules/apps/pinchflat.nix
@@ -1,0 +1,82 @@
+# Pinchflat - yt-dlp channel/playlist subscription manager
+# Native services.pinchflat from nixpkgs (Phoenix/Elixir app backed by
+# SQLite). User/group overridden to the shared server-${env}:servers
+# user so writes against /mnt/content/youtube land with the UID/GID
+# the NAS expects — pinchflat drops Jellyfin-friendly NFOs alongside
+# the media, and Jellyfin reads them via the same NFS share.
+# auth/caddy/homepage wiring is generated from
+# `myAuthentik.forwardAuthApps.pinchflat` by modules/platform/authentik.nix
+# (pinchflat ships no native OIDC — only BASIC_AUTH_* env vars — so we
+# gate it via forward-auth and skip the built-in basic auth entirely).
+#
+# SECRET_KEY_BASE is sourced from sops via secretsFile. The nixpkgs
+# module enforces an assertion that either `selfhosted = true` (weak
+# secret) or `secretsFile` is set; we go with sops. The key must be
+# a 64-byte hex string (`openssl rand -hex 64`).
+{ inputs, ... }:
+let
+  sopsFolder = (builtins.toString inputs.nix-secrets) + "/sops";
+in
+{
+  flake.modules.nixos.pinchflat =
+    {
+      config,
+      hostSpec,
+      ...
+    }:
+    let
+      port = 8945;
+    in
+    {
+      sops.secrets."pinchflat/secret_key_base" = {
+        sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
+        restartUnits = [ "pinchflat.service" ];
+      };
+
+      sops.templates."pinchflat.env" = {
+        content = ''
+          SECRET_KEY_BASE=${config.sops.placeholder."pinchflat/secret_key_base"}
+        '';
+        restartUnits = [ "pinchflat.service" ];
+      };
+
+      myAuthentik.forwardAuthApps.pinchflat = {
+        inherit port;
+        displayName = "Pinchflat";
+        homepage = {
+          group = "Acquisition";
+          icon = "pinchflat";
+          description = "YouTube subscription downloader";
+        };
+      };
+
+      services.pinchflat = {
+        enable = true;
+        inherit port;
+        # NFS UID alignment: pinchflat writes media + NFOs to the
+        # Synology share at /mnt/content/youtube. user/group creation
+        # in the module is gated behind cfg.user == "pinchflat", so
+        # overriding to the shared server-${env} user cleanly skips
+        # the module's user block.
+        user = "server-${hostSpec.serverEnvironment}";
+        group = "servers";
+        mediaDir = "/mnt/content/youtube";
+        secretsFile = config.sops.templates."pinchflat.env".path;
+      };
+
+      preservation.preserveAt."/persist".directories = [
+        {
+          directory = "/var/lib/pinchflat";
+          user = "server-${hostSpec.serverEnvironment}";
+          group = "servers";
+          mode = "0700";
+        }
+      ];
+
+      services.restic.backups.server.paths = [ "/var/lib/pinchflat" ];
+
+      mySqliteQuiesce.apps.pinchflat.databases = [
+        "/var/lib/pinchflat/db/pinchflat.db"
+      ];
+    };
+}

--- a/modules/profiles/server-apps.nix
+++ b/modules/profiles/server-apps.nix
@@ -58,6 +58,7 @@
         "/var/lib/komga"
         "/var/lib/mealie"
         "/var/lib/paperless-ngx"
+        "/var/lib/pinchflat"
         "/var/lib/private/authentik"
         "/var/lib/prowlarr"
         "/var/lib/radarr"
@@ -88,9 +89,11 @@
         maintainerr
         manyfold
         mealie
+        metube
         miniflux
         mylar3
         paperless-ngx
+        pinchflat
         profilarr
         prowlarr
         radarr


### PR DESCRIPTION
## Summary
- Adds `pinchflat` (native `services.pinchflat`) as a yt-dlp channel/playlist subscription manager — Jellyfin-friendly NFO output dropped under `/mnt/content/youtube`, SQLite-backed and in the sqlite-quiesce list, gated by authentik forward-auth (Infrastructure group).
- Adds `metube` (container `ghcr.io/alexta69/metube:2026.04.28`) as the ad-hoc yt-dlp web UI — downloads land in `/mnt/content/youtube/metube`, also gated by forward-auth.
- Both run as `server-${env}:servers` for NFS UID alignment so anything they write to the Synology share is visible to Jellyfin without UID translation.

Pinchflat's user creation is gated on `cfg.user == "pinchflat"`, so the `server-${env}` override cleanly skips the module's user block (the jellyfin/bazarr/sonarr pattern). Skipped pinchflat's built-in basic auth — redundant behind forward-auth — and skipped its (non-existent) OIDC story.

Closes #124.

## Left to validate
- **SECRET_KEY_BASE must be plumbed via sops by the user.** The pinchflat module references `config.sops.placeholder."pinchflat/secret_key_base"` — add a 64-byte hex value (`openssl rand -hex 64`) at sops key `pinchflat/secret_key_base` inside `${nix-secrets}/sops/<host>.yaml` before deploying. Without it, `sops-install-secrets` fails and `pinchflat.service` won't come up.
- Deploy + smoke test on the target host: confirm pinchflat reaches the UI behind authentik, accepts a YouTube channel as a source, downloads land under `/mnt/content/youtube/` with NFOs, Jellyfin picks them up. Confirm metube also reaches its UI behind authentik and ad-hoc downloads land under `/mnt/content/youtube/metube/`.
- Verify the sqlite-quiesce oneshot runs before the next restic snapshot — check `/var/backup/sqlite/pinchflat/pinchflat.db` exists post-backup.

## Test plan
- [ ] `task check` passes locally
- [ ] sops key `pinchflat/secret_key_base` populated in `<host>.yaml`
- [ ] `task deploy:<host>` succeeds
- [ ] `pinchflat.service` active, web UI reachable via authentik gate
- [ ] `podman-metube.service` active, web UI reachable via authentik gate
- [ ] pinchflat downloads a test channel under `/mnt/content/youtube/` with Jellyfin-friendly NFOs
- [ ] metube downloads a single URL into `/mnt/content/youtube/metube/`
- [ ] Jellyfin sees the new media without UID translation issues
- [ ] sqlite-quiesce oneshot stages `/var/backup/sqlite/pinchflat/pinchflat.db` before restic

This pull request and its description were written by Isaac.