### PR TITLE
unify homepage tile schema across authentik submodules — closes #140

### DIFF
--- a/modules/apps/actualbudget.nix
+++ b/modules/apps/actualbudget.nix
@@ -23,13 +23,12 @@ _: {
         appRestartUnit = "podman-actualbudget.service";
         clientIdVar = "ACTUAL_OPENID_CLIENT_ID";
         clientSecretVar = "ACTUAL_OPENID_CLIENT_SECRET";
+        displayName = "Actual Budget";
         homepage = {
           group = "Home";
           icon = "actual-budget";
           description = "Personal finance";
         };
-        homepageDisplayName = "Actual Budget";
-        homepageHref = "https://${actualHost}";
       };
 
       systemd.tmpfiles.rules = [

--- a/modules/apps/audiobookshelf.nix
+++ b/modules/apps/audiobookshelf.nix
@@ -16,13 +16,12 @@ _: {
       myAuthentik.oidcApps.audiobookshelf = {
         blueprintsDir = ./audiobookshelf-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "Audiobookshelf";
         homepage = {
           group = "Consumption";
           icon = "audiobookshelf";
           description = "Audiobooks";
         };
-        homepageDisplayName = "Audiobookshelf";
-        homepageHref = "https://${audiobookshelfHost}";
       };
 
       services.audiobookshelf = {

--- a/modules/apps/grimmory.nix
+++ b/modules/apps/grimmory.nix
@@ -52,13 +52,12 @@ in
             ];
           };
         };
+        displayName = "Grimmory";
         homepage = {
           group = "Consumption";
           icon = "booklore";
           description = "Digital library";
         };
-        homepageDisplayName = "Grimmory";
-        homepageHref = "https://${grimmoryHost}";
       };
 
       services.mysql = {

--- a/modules/apps/homeassistant.nix
+++ b/modules/apps/homeassistant.nix
@@ -50,13 +50,12 @@ _: {
       myAuthentik.oidcApps.homeassistant = {
         blueprintsDir = ./homeassistant-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "Home Assistant";
         homepage = {
           group = "Home";
           icon = "home-assistant";
           description = "Smart home";
         };
-        homepageDisplayName = "Home Assistant";
-        homepageHref = "https://${homeassistantHost}";
       };
 
       networking = {

--- a/modules/apps/kavita.nix
+++ b/modules/apps/kavita.nix
@@ -27,13 +27,12 @@ _: {
       myAuthentik.oidcApps.kavita = {
         blueprintsDir = ./kavita-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "Kavita";
         homepage = {
           group = "Consumption";
           icon = "kavita";
           description = "Manga + books";
         };
-        homepageDisplayName = "Kavita";
-        homepageHref = "https://${kavitaHost}";
       };
 
       services.kavita = {

--- a/modules/apps/komga.nix
+++ b/modules/apps/komga.nix
@@ -27,13 +27,12 @@ _: {
         appRestartUnit = "komga.service";
         clientIdVar = "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AUTHENTIK_CLIENT_ID";
         clientSecretVar = "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AUTHENTIK_CLIENT_SECRET";
+        displayName = "Komga";
         homepage = {
           group = "Consumption";
           icon = "komga";
           description = "Comics + manga";
         };
-        homepageDisplayName = "Komga";
-        homepageHref = "https://${komgaHost}";
       };
 
       services.komga = {

--- a/modules/apps/mealie.nix
+++ b/modules/apps/mealie.nix
@@ -35,13 +35,12 @@ _: {
       myAuthentik.oidcApps.mealie = {
         blueprintsDir = ./mealie-blueprints;
         appRestartUnit = "mealie.service";
+        displayName = "Mealie";
         homepage = {
           group = "Home";
           icon = "mealie";
           description = "Recipe manager";
         };
-        homepageDisplayName = "Mealie";
-        homepageHref = "https://${mealieHost}";
       };
 
       services.mealie = {

--- a/modules/apps/miniflux.nix
+++ b/modules/apps/miniflux.nix
@@ -31,13 +31,12 @@ _: {
         appRestartUnit = "miniflux.service";
         clientIdVar = "OAUTH2_CLIENT_ID";
         clientSecretVar = "OAUTH2_CLIENT_SECRET";
+        displayName = "Miniflux";
         homepage = {
           group = "Consumption";
           icon = "miniflux";
           description = "RSS reader";
         };
-        homepageDisplayName = "Miniflux";
-        homepageHref = "https://${minifluxHost}";
       };
 
       services.miniflux = {

--- a/modules/apps/paperless-ngx.nix
+++ b/modules/apps/paperless-ngx.nix
@@ -64,13 +64,12 @@ in
             config.sops.placeholder."paperless-ngx/oidc_client_secret"
           }","settings":{"server_url":"https://${authentikHost}/application/o/paperless-ngx/.well-known/openid-configuration","fetch_userinfo":true}}],"SCOPE":["openid","profile","email"]}}
         '';
+        displayName = "Paperless-ngx";
         homepage = {
           group = "Home";
           icon = "paperless-ngx";
           description = "Documents";
         };
-        homepageDisplayName = "Paperless-ngx";
-        homepageHref = "https://${paperlessHost}";
       };
 
       services.paperless = {

--- a/modules/apps/readmeabook.nix
+++ b/modules/apps/readmeabook.nix
@@ -35,13 +35,12 @@ _: {
       myAuthentik.oidcApps.readmeabook = {
         blueprintsDir = ./readmeabook-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "ReadMeABook";
         homepage = {
           group = "Requests";
           icon = "audiobookshelf";
           description = "Audiobook requests";
         };
-        homepageDisplayName = "ReadMeABook";
-        homepageHref = "https://${readmeabookHost}";
       };
 
       systemd = {

--- a/modules/apps/seerr.nix
+++ b/modules/apps/seerr.nix
@@ -24,13 +24,12 @@ _: {
       myAuthentik.oidcApps.seerr = {
         blueprintsDir = ./seerr-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "Seerr";
         homepage = {
           group = "Requests";
           icon = "jellyseerr";
           description = "Media requests";
         };
-        homepageDisplayName = "Seerr";
-        homepageHref = "https://${seerrHost}";
       };
 
       systemd.tmpfiles.rules = [

--- a/modules/apps/shelfarr.nix
+++ b/modules/apps/shelfarr.nix
@@ -34,13 +34,12 @@ _: {
       myAuthentik.oidcApps.shelfarr = {
         blueprintsDir = ./shelfarr-blueprints;
         clientCredsInAppEnv = false;
+        displayName = "Shelfarr";
         homepage = {
           group = "Requests";
           icon = "shelfarr";
           description = "Book + audiobook requests";
         };
-        homepageDisplayName = "Shelfarr";
-        homepageHref = "https://${shelfarrHost}";
       };
 
       systemd.tmpfiles.rules = [

--- a/modules/apps/tandoor.nix
+++ b/modules/apps/tandoor.nix
@@ -53,13 +53,12 @@ in
             config.sops.placeholder."tandoor/oidc_client_secret"
           }","settings":{"server_url":"https://${authentikHost}/application/o/tandoor/.well-known/openid-configuration"}}]}}
         '';
+        displayName = "Tandoor";
         homepage = {
           group = "Home";
           icon = "tandoor-recipes";
           description = "Recipe manager";
         };
-        homepageDisplayName = "Tandoor";
-        homepageHref = "https://${tandoorHost}";
       };
 
       systemd.tmpfiles.rules = [

--- a/modules/platform/authentik.nix
+++ b/modules/platform/authentik.nix
@@ -136,6 +136,14 @@ in
             type = lib.types.str;
             description = "Short blurb shown beneath the app on the homepage tile.";
           };
+          weight = lib.mkOption {
+            type = lib.types.nullOr lib.types.int;
+            default = null;
+            description = ''
+              Sort weight within the group (lower renders first). Null
+              defers to the homepage tile default (0).
+            '';
+          };
         };
       });
 
@@ -384,6 +392,22 @@ in
                       via `extraEnvLines`.
                     '';
                   };
+                  displayName = lib.mkOption {
+                    type = lib.types.str;
+                    default = name;
+                    description = ''
+                      Human-facing app name (homepage tile label).
+                      Defaults to the attribute name.
+                    '';
+                  };
+                  href = lib.mkOption {
+                    type = lib.types.str;
+                    default = "https://${name}.${hostSpec.serverDomain}";
+                    description = ''
+                      Homepage tile target URL. Defaults to
+                      `https://<name>.<serverDomain>`.
+                    '';
+                  };
                   homepage = lib.mkOption {
                     type = lib.types.nullOr homepageSubmodule;
                     default = null;
@@ -391,16 +415,6 @@ in
                       Homepage tile metadata. Set to null (default) to
                       skip generating a tile.
                     '';
-                  };
-                  homepageDisplayName = lib.mkOption {
-                    type = lib.types.str;
-                    default = name;
-                    description = "Tile label. Defaults to the attribute name.";
-                  };
-                  homepageHref = lib.mkOption {
-                    type = lib.types.str;
-                    default = "https://${name}.${hostSpec.serverDomain}";
-                    description = "Tile target URL. Defaults to <name>.<serverDomain>.";
                   };
                 };
               }
@@ -430,11 +444,15 @@ in
                 '';
           }) fwApps;
 
-          myHomepage.tiles = lib.mapAttrs (_name: app: {
-            inherit (app.homepage) group icon description;
-            inherit (app) displayName;
-            href = "https://${app.host}";
-          }) (lib.filterAttrs (_: app: app.homepage != null) fwApps);
+          myHomepage.tiles = lib.mapAttrs (
+            _name: app:
+            {
+              inherit (app.homepage) group icon description;
+              inherit (app) displayName;
+              href = "https://${app.host}";
+            }
+            // lib.optionalAttrs (app.homepage.weight != null) { inherit (app.homepage) weight; }
+          ) (lib.filterAttrs (_: app: app.homepage != null) fwApps);
         })
 
         (lib.mkIf (oidcApps != { }) {
@@ -490,11 +508,14 @@ in
 
           myAuthentik.extraBlueprints = lib.mapAttrsToList (_: app: app.blueprintsDir) oidcApps;
 
-          myHomepage.tiles = lib.mapAttrs (_name: app: {
-            inherit (app.homepage) group icon description;
-            displayName = app.homepageDisplayName;
-            href = app.homepageHref;
-          }) (lib.filterAttrs (_: app: app.homepage != null) oidcApps);
+          myHomepage.tiles = lib.mapAttrs (
+            _name: app:
+            {
+              inherit (app.homepage) group icon description;
+              inherit (app) displayName href;
+            }
+            // lib.optionalAttrs (app.homepage.weight != null) { inherit (app.homepage) weight; }
+          ) (lib.filterAttrs (_: app: app.homepage != null) oidcApps);
         })
       ];
     };


### PR DESCRIPTION
## Summary
- Collapse `myAuthentik.oidcApps.<name>` tile metadata to the same shape as `forwardAuthApps`: top-level `displayName` + `href` (each with sensible defaults derived from the attr name + `hostSpec.serverDomain`), and a nested `homepage = { group; icon; description; weight ? null; }`. Drops the redundant `homepageDisplayName` / `homepageHref` options.
- Add an optional `weight` knob to the shared homepage submodule (used by both `forwardAuthApps` and `oidcApps`); `null` defers to the `myHomepage.tiles` default of 0.
- Remove the hand-typed `homepageHref = "https://${<app>Host}"` strings from every OIDC app caller (actualbudget, audiobookshelf, grimmory, homeassistant, kavita, komga, mealie, miniflux, paperless-ngx, readmeabook, seerr, shelfarr, tandoor) and keep the non-default `displayName` overrides as top-level `displayName = "..."`.

## Validation performed
- nixfmt clean, task lint clean
- `nix flake check --all-systems` deferred to CI (PR #159 workflow) due to parallel-agent nix-daemon contention

## Left to validate
- CI eval pass
- Live deploy — confirm tiles still render with correct labels + URLs

Closes #140

PR drafted by Claude.