### PR TITLE
bump caddy plugin closure hash for current nixpkgs

### DIFF
--- a/modules/system/caddy.nix
+++ b/modules/system/caddy.nix
@@ -74,7 +74,7 @@ in
               # renovate: datasource=github-tags depName=caddy-dns/cloudflare
               "github.com/caddy-dns/cloudflare@v0.2.4"
             ];
-            hash = "sha256-uKtStb6m1/hA5IaAdIyLGzAQdyIySjISdxXIRxehhyI=";
+            hash = "sha256-vNSHU7txQLs0m0UChuszURXjEoMj4r1902+1ei0/DaI=";
           };
           globalConfig = ''
             acme_dns cloudflare {env.CLOUDFLARE_API_TOKEN}


### PR DESCRIPTION
## Summary

Caddy go-module vendoring changed in the latest nixos-25.11 channel bump (commit c7979e8 \"patch flake\"). Builds on main were failing with:

\`\`\`
specified: sha256-uKtStb6m1/hA5IaAdIyLGzAQdyIySjISdxXIRxehhyI=
got:       sha256-vNSHU7txQLs0m0UChuszURXjEoMj4r1902+1ei0/DaI=
\`\`\`

New hash picked up from the mismatch printed during hpp-1 rebuild.

## Test plan

- [x] \`task check\` passes
- [x] \`task deploy:hpp-1\` builds and switches cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)