### PR TITLE
automerge renovate patch/digest updates, exclude caddy plugins — closes #144

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,18 @@
     "enabled": true,
     "schedule": ["before 4am on monday"]
   },
+  "packageRules": [
+    {
+      "description": "Auto-merge low-risk updates (patch versions + image digest refreshes) after CI green.",
+      "matchUpdateTypes": ["patch", "digest", "pinDigest"],
+      "automerge": true
+    },
+    {
+      "description": "Caddy plugin bumps require regenerating the pkgs.caddy.withPlugins hash in modules/system/caddy.nix; keep manual.",
+      "matchPackageNames": ["/caddy/"],
+      "automerge": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Adds a `packageRules` block to `renovate.json` so renovate can self-merge low-risk bumps now that CI gates `main` (#133).

- Auto-merge `updateType ∈ {patch, digest, pinDigest}` once CI is green.
- Carve-out: any package whose depName contains `caddy` stays manual. The Caddy plugin set (`caddy-dns/*`, picked up by the third custom regex manager) is pinned via `pkgs.caddy.withPlugins` in `modules/system/caddy.nix:73` with a hand-rolled `hash =`; renovate has no way to refresh that hash, so every bump needs a human to rebuild and update it.

Mirrors the sketch in #144, using the modern `matchPackageNames` regex form (`matchPackagePatterns` was deprecated in renovate v37).

## Audit of other regex managers

- Docker image **tags** — `services/apps/*.nix`. Pure container image refs, no nixpkgs coupling. Safe to automerge on patch/digest.
- Docker image **digests** — same files. Pure rebases on an existing tag. Safest case.
- Caddy plugin versions — only renovate-managed dep that's coupled to a nixpkgs-side hash. Excluded above.

## Test plan

- [x] `jq . renovate.json` — valid JSON.
- [x] `renovate-config-validator renovate.json` — `Config validated successfully`.
- [x] `task fmt-check` / `task lint` — clean.
- [ ] First post-merge renovate run produces a patch/digest PR that auto-merges after the `check` workflow goes green (will observe on the next renovate cycle).
- [ ] Any future caddy-dns plugin bump opens a PR but does **not** automerge (will observe when one lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)