### PR TITLE
vector: drop cadvisor libpod-lookup noise

### DIFF
--- a/modules/system/vector.nix
+++ b/modules/system/vector.nix
@@ -44,6 +44,26 @@ _: {
             # since vector persists the cursor.
           };
 
+          # cAdvisor floods the journal with one line per podman
+          # container per housekeeping cycle (~33/min, ~47k/day on
+          # hpp-1) trying to read podman's `containers.json` storage
+          # metadata — the cgroup-level metrics it ships still work,
+          # only the libpod label-enrichment lookup fails. Drop just
+          # the matching message; keep everything else cadvisor logs
+          # so genuine collector errors stay visible (closes #192).
+          transforms.drop_cadvisor_libpod_noise = {
+            type = "filter";
+            inputs = [ "journald" ];
+            condition = {
+              type = "vrl";
+              source = ''
+                unit = to_string(._SYSTEMD_UNIT) ?? ""
+                msg = to_string(.message) ?? ""
+                !(unit == "cadvisor.service" && contains(msg, "Failed to create existing container"))
+              '';
+            };
+          };
+
           # Add query-friendly aliases (`unit`, `level`) without
           # deleting the raw underscored journal fields — keeping both
           # means existing dashboards/alerts that key off `unit` and
@@ -53,7 +73,7 @@ _: {
           # this swap.
           transforms.journal_enrich = {
             type = "remap";
-            inputs = [ "journald" ];
+            inputs = [ "drop_cadvisor_libpod_noise" ];
             source = ''
               if exists(._SYSTEMD_UNIT) {
                 .unit = ._SYSTEMD_UNIT


### PR DESCRIPTION
## Summary
- cAdvisor logs ~33/min "Failed to create existing container" lines from libpod label-enrichment; the cgroup-level container_* metrics keep flowing, only the optional name/image enrichment fails.
- Filter the matching message at vector before VictoriaLogs ingest. Other cadvisor logs (startup, housekeeping, real collector errors) still flow through.
- Validated on hpp-1: 68 noisy journal lines in 2 min → 0 reach VL; 54 legitimate cadvisor lines do.

Closes #192

## Test plan
- [x] task check passes
- [x] task deploy:hpp-1 succeeds
- [x] Vector running, filter dropping target lines
- [x] cAdvisor metrics still flowing (container_cpu_usage_seconds_total, container_memory_rss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)