### PR TITLE
auto-rebuild: fetch nix-secrets via system-level SSH key

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,18 +29,15 @@ jobs:
             lazy-trees = false
             always-allow-substitutes = false
 
-      # nix-secrets is a private flake input fetched via git+https from
+      # nix-secrets is a private flake input fetched via git+ssh from
       # github.com/ianepreston/nix-secrets. Inside CI we use a deploy
-      # key (read-only) registered on that repo to authenticate, and
-      # rewrite https → ssh so nix's git fetcher picks up the agent.
+      # key (read-only) registered on that repo to authenticate; the
+      # ssh-agent loaded here is what nix's git fetcher picks up when
+      # cloning the input.
       - name: Authorize nix-secrets clone
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.NIX_SECRETS_DEPLOY_KEY }}
-
-      - name: Rewrite github.com https → ssh for nix-secrets fetch
-        run: |
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
 
       # `nix flake check --all-systems` evaluates every config in
       # parallel and on Determinate Nix's Linux runner consistently

--- a/flake.lock
+++ b/flake.lock
@@ -499,13 +499,13 @@
         "rev": "06f24899ad6ad82c1a0295d2fcb79366eebf543c",
         "shallow": true,
         "type": "git",
-        "url": "https://github.com/ianepreston/nix-secrets.git"
+        "url": "ssh://git@github.com/ianepreston/nix-secrets.git"
       },
       "original": {
         "ref": "main",
         "shallow": true,
         "type": "git",
-        "url": "https://github.com/ianepreston/nix-secrets.git"
+        "url": "ssh://git@github.com/ianepreston/nix-secrets.git"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,9 +44,13 @@
     # ========= Personal Repositories =========
     #
     # Private secrets repo.  See ./docs/secretsmgmt.md
-    # Authenticate via ssh and use shallow clone
+    # Authenticate via ssh and use shallow clone. SSH (not HTTPS) so the
+    # nightly `nixos-upgrade.service` on impermanent server hosts can
+    # fetch with a system-level deploy key — root has no HTTPS creds and
+    # the user's home-manager-managed SSH key isn't materialized at
+    # 04:40 when the timer fires (see modules/system/auto-rebuild.nix).
     nix-secrets = {
-      url = "git+https://github.com/ianepreston/nix-secrets.git?ref=main&shallow=1";
+      url = "git+ssh://git@github.com/ianepreston/nix-secrets.git?ref=main&shallow=1";
       inputs = { };
     };
     # Native NixOS module for authentik (server, worker, outposts).

--- a/modules/system/auto-rebuild.nix
+++ b/modules/system/auto-rebuild.nix
@@ -2,7 +2,11 @@
 # Periodically fetch latest config from GitHub and rebuild
 _: {
   flake.modules.nixos.auto-rebuild =
-    { hostSpec, ... }:
+    {
+      config,
+      hostSpec,
+      ...
+    }:
     {
       system.autoUpgrade = {
         enable = true;
@@ -14,16 +18,27 @@ _: {
         allowReboot = true;
       };
 
-      # The flake depends on a private repo (nix-secrets). Its URL is
-      # git+https://... (kept that way so Renovate can read it), but root
-      # has no GitHub HTTPS creds. Rewrite to SSH at fetch time via git
-      # config env vars and point GIT_SSH at the user's key — mirroring
-      # the insteadOf rule in the user's home-manager gitconfig.
+      # The flake depends on a private repo (nix-secrets) and fetches it
+      # over SSH (see `nix-secrets` input in flake.nix). Provision the
+      # per-host SSH key at the system level — root-owned, available
+      # straight out of `sops-install-secrets.service` so it's ready
+      # when the 04:40 timer fires regardless of whether the user has
+      # logged in. The user's home-manager copy at
+      # `${hostSpec.home}/.ssh/id_ed25519` is materialized by the
+      # `sops-nix` *user* service on session start and is absent on
+      # impermanent hosts after a reboot — pointing nixos-upgrade at
+      # the system path side-steps that race entirely.
+      sops.secrets."ssh/ed25519" = {
+        inherit (hostSpec) sopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+
       systemd.services.nixos-upgrade.environment = {
-        GIT_SSH_COMMAND = "ssh -i ${hostSpec.home}/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new";
-        GIT_CONFIG_COUNT = "1";
-        GIT_CONFIG_KEY_0 = "url.git@github.com:ianepreston/.insteadOf";
-        GIT_CONFIG_VALUE_0 = "https://github.com/ianepreston/";
+        GIT_SSH_COMMAND = "ssh -i ${
+          config.sops.secrets."ssh/ed25519".path
+        } -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes";
       };
     };
 }


### PR DESCRIPTION
## Summary

- Move the nix-secrets clone for `nixos-upgrade.service` off the user's home-manager-materialized SSH key and onto a root-owned, sops-provisioned system key.
- Switch the flake input URL from `git+https://` to `git+ssh://` so the unit no longer needs the `insteadOf` rewrite hack to use SSH.
- Update CI's check workflow comment to match (the deploy-key + ssh-agent step already worked for either URL; the redundant `insteadOf` rewrite is dropped).

## Why

On impermanent server hosts (`hpp-1`, `testvm`) `/home/ipreston` is wiped on every reboot. The home-manager sops-nix *user* service that materializes `~/.ssh/id_ed25519` only fires on session start, so at 04:40 when the `nixos-upgrade.service` timer runs the key path doesn't exist yet and the fetch fails (closes #193). Provisioning the same key at the NixOS sops level binds it to `sops-install-secrets.service`, which is up by sysinit and ready long before the upgrade timer.

## Test plan

- [x] `task check` passes (fmt-check, statix, deadnix, `nix flake check --all-systems`).
- [x] `nix build .#nixosConfigurations.hpp-1.config.system.build.toplevel` succeeds with the new flake URL.
- [x] Inspected the rendered `nixos-upgrade.service` unit — `GIT_SSH_COMMAND` now points at `/run/secrets/ssh/ed25519` and the `GIT_CONFIG_*` insteadOf vars are gone.
- [x] `nix flake metadata` resolves the new `git+ssh://` nix-secrets input cleanly.
- [ ] After merge: `task deploy:hpp-1`, then `sudo systemctl start nixos-upgrade.service` on hpp-1 to confirm the first real fetch works against the system-level key without a logged-in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)