### PR TITLE
apprise-sabnzbd-config: order after sops decryption

### DIFF
--- a/modules/apps/sabnzbd.nix
+++ b/modules/apps/sabnzbd.nix
@@ -83,6 +83,18 @@ _: {
         description = "Render apprise stateful config for sabnzbd";
         wantedBy = [ "multi-user.target" ];
         before = [ "podman-apprise.service" ];
+        # Explicit ordering on the sops decryption unit
+        # (sops.useSystemdActivation = true in modules/system/sops.nix).
+        # Without this, EnvironmentFile= points at
+        # /run/secrets/rendered/apprise-sabnzbd.env before sops has
+        # rendered the template, the unit fails with "Failed to load
+        # environment files", and only the sops template's restartUnits
+        # hook (which fires after rendering) recovers it ~minutes later.
+        # See #194. ConditionPathExists below belt-and-suspenders the
+        # case where sops *finishes* but this specific render failed.
+        after = [ "sops-install-secrets.service" ];
+        wants = [ "sops-install-secrets.service" ];
+        unitConfig.ConditionPathExists = config.sops.templates."apprise-sabnzbd.env".path;
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;


### PR DESCRIPTION
## Summary
- Adds `after`/`wants` on `sops-install-secrets.service` plus a `ConditionPathExists` guard to `apprise-sabnzbd-config.service`, mirroring the pattern already used by the postgres `*-db-password` units.
- Without explicit ordering, the unit's `EnvironmentFile=/run/secrets/rendered/apprise-sabnzbd.env` was being read before sops finished rendering templates at boot, causing the `Failed to load environment files` cascade described in #194. The sops template's `restartUnits` hook eventually recovered it minutes later.

Closes #194.

## Test plan
- [x] `task check` passes
- [x] `task deploy:hpp-1` succeeds and rebuilds the unit
- [x] Reboot hpp-1 — `apprise-sabnzbd-config.service` is `active (exited)` on first start, no `Failed to load environment files` in the boot journal, `podman-apprise` and `sabnzbd` come up clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)