### PR TITLE
mariadb: fix tc.log corruption from preservation tmpfiles ownership

### DIFF
--- a/modules/apps/grimmory.nix
+++ b/modules/apps/grimmory.nix
@@ -68,6 +68,15 @@ _: {
         ];
 
         services = {
+          # Explicit ordering on mariadb so the container stops before
+          # mariadb on shutdown. Transitive ordering through
+          # grimmory-db-password.service (a RemainAfterExit oneshot)
+          # should give the same guarantee, but the issue #195 audit
+          # called that out as fragile — make it explicit.
+          podman-grimmory = {
+            after = [ "mysql.service" ];
+          };
+
           # Sets up the grimmory mariadb role with a sops-managed password
           # and grants on the grimmory database. ensureUsers can't help
           # here because it provisions unix_socket auth only, but the

--- a/modules/system/preservation-server.nix
+++ b/modules/system/preservation-server.nix
@@ -60,7 +60,25 @@
 
           # ----- Databases (data dirs; dumps are recovery) -----
           "/var/lib/postgresql"
-          "/var/lib/mysql"
+          # mariadb writes ib_buffer_pool.incomplete and deletes tc.log
+          # directly in this dir during shutdown — unlike postgres which
+          # writes to a versioned subdirectory. Preservation's default
+          # root:root 0755 (bind-mount source's perms on /persist/...)
+          # propagates here and matches 00-nixos.conf's mode but not its
+          # owner, so a `systemd-tmpfiles --create` mid-deploy reverts
+          # /var/lib/mysql from mysql:mysql to root:root. Mariadb then
+          # gets EACCES on the next shutdown's buffer-pool dump and
+          # tc.log unlink → tc.log header left half-written → next
+          # boot's crash recovery fails with "Bad magic header in tc
+          # log" and an 11-minute systemd-retry cascade. Pinning owner
+          # and mode to match 00-nixos.conf keeps mysql writable through
+          # tmpfiles-resetup. Closes #195.
+          {
+            directory = "/var/lib/mysql";
+            user = "mysql";
+            group = "mysql";
+            mode = "0755";
+          }
 
           # ----- Dump staging -----
           # The morning's postgres/mariadb dumps land here and restic
@@ -72,6 +90,16 @@
           # ----- Container app state -----
           # Every podman-managed app's volumes live under here.
           "/var/lib/containers"
+
+          # ----- Logs -----
+          # Persist journald across reboots. /var/log is on the wiped
+          # rootfs, so without this every boot drops prior journals and
+          # `journalctl --list-boots` only sees the current boot.
+          # journald's default storage=auto writes here when the dir
+          # exists, so persisting it is sufficient — no extra config
+          # needed. Closes #195 (diagnostic gap for the mariadb tc.log
+          # corruption investigation).
+          "/var/log/journal"
 
           # ----- Observability -----
           # Prometheus TSDB (15d) + Loki chunks/index (7d). The


### PR DESCRIPTION
## Summary
- Root cause: preservation's tmpfiles entry for `/var/lib/mysql` defaulted to `root:root 0755` (via the bind-mount source on `/persist`), so every `systemd-tmpfiles-resetup` run (each `task deploy`) flipped the live dir to root:root. Mariadb then hit EACCES on the next shutdown's buffer-pool dump and `tc.log` unlink, leaving a half-written tc.log header → next boot's "Bad magic header" crash-recovery cascade. Pin preservation's entry to `mysql:mysql 0755` to match `00-nixos.conf`.
- Also persists `/var/log/journal` (issue's item 1 — the diagnostic gap that hid this for two recurrences) and adds explicit `After=mysql.service` to `podman-grimmory.service` (issue's item 2).
- Items 3–5 (ExecStartPre auto-recovery, `TimeoutStopUSec` bump, post-incident re-eval) are not needed once the EACCES root cause is fixed.

## Test plan
- [x] `task check` passes
- [x] Deploy + reboot on hpp-1 produces a clean mysql shutdown ("Dumping buffer pool", "Shutdown complete", no permission-denied) and a clean start (no "Recovering after a crash using tc.log")
- [x] Verified `/var/lib/mysql` ownership survives a deploy-triggered `systemd-tmpfiles-resetup`

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)