### PR TITLE
recovery: clean restore with restic --delete — closes #217

### DIFF
--- a/modules/apps/pinchflat.nix
+++ b/modules/apps/pinchflat.nix
@@ -13,11 +13,7 @@
 # module enforces an assertion that either `selfhosted = true` (weak
 # secret) or `secretsFile` is set; we go with sops. The key must be
 # a 64-byte hex string (`openssl rand -hex 64`).
-{ inputs, ... }:
-let
-  sopsFolder = (builtins.toString inputs.nix-secrets) + "/sops";
-in
-{
+_: {
   flake.modules.nixos.pinchflat =
     {
       config,
@@ -29,7 +25,7 @@ in
     in
     {
       sops.secrets."pinchflat/secret_key_base" = {
-        sopsFile = "${sopsFolder}/${hostSpec.hostName}.yaml";
+        inherit (hostSpec) sopsFile;
         restartUnits = [ "pinchflat.service" ];
       };
 

--- a/taskfiles/recovery.yaml
+++ b/taskfiles/recovery.yaml
@@ -70,9 +70,12 @@ tasks:
           includes="\$includes --include \$p"
         done
         echo "[+] Restoring paths: {{.PATHS}}"
+        # --delete: remove files at the destination within the included
+        # paths that aren't in the snapshot. Makes restore a clean
+        # operation rather than an overlay — see issue #217.
         # shellcheck disable=SC2086
         restic -r "\$REPO" --password-file "\$PASS_FILE" \
-          restore latest --target / \$includes
+          restore latest --target / --delete \$includes
 
         for u in {{.UNITS}}; do
           echo "[+] Starting \$u"
@@ -114,9 +117,10 @@ tasks:
           includes="\$includes --include \$p"
         done
         echo "[+] Restoring /var/backup/postgresql {{.PATHS}}"
+        # --delete: see comment in _restore-volume.
         # shellcheck disable=SC2086
         restic -r "\$REPO" --password-file "\$PASS_FILE" \
-          restore latest --target / \$includes
+          restore latest --target / --delete \$includes
 
         echo "[+] Replaying \$DB database from pg_dumpall"
         sudo -u postgres dropdb --if-exists "\$DB"
@@ -173,9 +177,10 @@ tasks:
           includes="\$includes --include \$p"
         done
         echo "[+] Restoring paths: {{.PATHS}}"
+        # --delete: see comment in _restore-volume.
         # shellcheck disable=SC2086
         restic -r "\$REPO" --password-file "\$PASS_FILE" \
-          restore latest --target / \$includes
+          restore latest --target / --delete \$includes
 
         for triple in {{.SWAPS}}; do
           IFS=":" read -r src dst owner <<<"\$triple"
@@ -1018,12 +1023,47 @@ tasks:
               ;;
           esac
         done
+      - |
+        set -euo pipefail
+        # Seed sentinel files inside the paths the upcoming restores
+        # will --include. If the snapshot doesn't contain these names
+        # (and it won't — they're random), --delete should remove them,
+        # locking in clean-restore semantics. See issue #217.
+        echo -e "\x1B[32m[+] Seeding sentinel files to verify clean-restore semantics\x1B[0m"
+        ssh -p {{.SSH_PORT}} -o StrictHostKeyChecking=accept-new ipreston@127.0.0.1 \
+          'sudo bash -se' <<'EOF'
+        set -euo pipefail
+        mkdir -p /var/lib/mealie /var/lib/jellyfin /var/backup/sqlite/jellyfin
+        touch /var/lib/mealie/.recovery-overlay-sentinel
+        touch /var/lib/jellyfin/.recovery-overlay-sentinel
+        touch /var/backup/sqlite/jellyfin/.recovery-overlay-sentinel
+        echo "[+] sentinels placed"
+        EOF
       - task: mealie
         vars: { HOST: tests-server, DEST: 127.0.0.1, SSH_PORT: '{{.SSH_PORT}}', SOURCE_HOST: '{{.SOURCE_HOST}}' }
       - task: miniflux
         vars: { HOST: tests-server, DEST: 127.0.0.1, SSH_PORT: '{{.SSH_PORT}}', SOURCE_HOST: '{{.SOURCE_HOST}}' }
       - task: jellyfin
         vars: { HOST: tests-server, DEST: 127.0.0.1, SSH_PORT: '{{.SSH_PORT}}', SOURCE_HOST: '{{.SOURCE_HOST}}' }
+      - |
+        set -euo pipefail
+        echo -e "\x1B[32m[+] Asserting sentinels were removed by --delete\x1B[0m"
+        ssh -p {{.SSH_PORT}} ipreston@127.0.0.1 'sudo bash -se' <<'EOF'
+        set -euo pipefail
+        failed=0
+        for f in \
+          /var/lib/mealie/.recovery-overlay-sentinel \
+          /var/lib/jellyfin/.recovery-overlay-sentinel \
+          /var/backup/sqlite/jellyfin/.recovery-overlay-sentinel; do
+          if [ -e "$f" ]; then
+            echo "[!] OVERLAY REGRESSION: $f survived restore"
+            failed=1
+          else
+            echo "[+] OK: $f removed by --delete"
+          fi
+        done
+        exit "$failed"
+        EOF
       - task: tests-server:down
       - |
         echo ""


### PR DESCRIPTION
## Summary

- Add `--delete` to all three restic restore templates (`_restore-volume`, `_restore-pg`, `_restore-sqlite`) so per-app recovery actually wipes destination state that isn't in the snapshot, instead of overlaying onto pre-existing cruft.
- Extend `recovery:test:full` with a sentinel-file check that seeds `.recovery-overlay-sentinel` files into the paths the upcoming restores will include and asserts they're gone afterward. Locks in clean-restore semantics so a future change can't silently regress to overlay behaviour.
- Drive-by: fix `modules/apps/pinchflat.nix` to inherit `sopsFile` from `hostSpec` instead of hardcoding `${hostSpec.hostName}.yaml`. The hardcoded path broke tests-server (whose hostSpec deliberately overrides `sopsFile` to `hpp-1.yaml`), which had been silently failing `sops-install-secrets` and blocking the quarterly drill since pinchflat was added in #175.

## Test plan

- [x] `task check` — fmt + lint + flake check
- [x] `task recovery:test:full` against hpp-1 — full VM bootstrap + restore mealie/miniflux/jellyfin, sentinel assertions confirm `--delete` removes orphan files in all three exercised paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)