### PR TITLE
ci: self-hosted GHA runner on hpp-1 — closes #180

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,14 +49,6 @@ jobs:
       # config sequentially via drvPath avoids the race and is the
       # coverage that matters (darwin/home configs are deployed from
       # local Darwin where local task check already gates them).
-      #
-      # Per-host builds (`nix build .#nixosConfigurations.<host>...`)
-      # are deliberately NOT in this workflow: hpp-1's full server
-      # closure (authentik via napalm's npm frontend, paperless lxml
-      # extensions, tesseract, etc.) takes ~60-90 min from cold on
-      # the 16G GHA runner even serialized — too slow to gate merges
-      # against. Builds come back in once we have a binary cache or
-      # a self-hosted runner; see #180.
       - name: Eval each NixOS config
         run: |
           set -euo pipefail
@@ -68,3 +60,51 @@ jobs:
             echo
             echo "::endgroup::"
           done
+
+  build:
+    name: build ${{ matrix.host }}
+    # Self-hosted runner on hpp-1 shares its warm /nix/store with CI,
+    # so unchanged closures rebuild in seconds. See #180 for the design.
+    #
+    # PR-from-fork guard: a fork PR can edit this workflow and run
+    # arbitrary code on our host. Restrict the build job to push events
+    # and to PRs whose head branch lives in this repo. Fork PRs still
+    # get `flake-check` above (cloud runner, no host access).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, nixos]
+    strategy:
+      # Surface every failing host on a single PR rather than bailing
+      # on the first red.
+      fail-fast: false
+      matrix:
+        # hpp-1 exercises the full server profile (server + server-apps);
+        # terra exercises the workstation profile. Terra builds on hpp-1
+        # hit the warm store for everything except terra-specific
+        # hardware/wm bits — net: a few seconds-to-minutes cold, free
+        # warm.
+        host: [hpp-1, terra]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            lazy-trees = false
+            always-allow-substitutes = false
+
+      - name: Authorize nix-secrets clone
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.NIX_SECRETS_DEPLOY_KEY }}
+
+      - name: Build ${{ matrix.host }}
+        run: |
+          nix build \
+            --print-build-logs \
+            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel"

--- a/flake.lock
+++ b/flake.lock
@@ -493,10 +493,10 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1779139764,
-        "narHash": "sha256-QHmQuAiyHTJca5o5HxCRwmjLK3Z0qsi2Nfh7AH9eUYA=",
+        "lastModified": 1779209645,
+        "narHash": "sha256-lH5OxyC0W1Kly0MDu/MVbzyTl84ma17fvzFwcUwoxpo=",
         "ref": "main",
-        "rev": "33bded1fb3adf619e973520bfb4fca04d027c229",
+        "rev": "8c5ddf02c30912aaa4afec089fe3233211e23d6d",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/ianepreston/nix-secrets.git"

--- a/modules/hosts/hpp-1.nix
+++ b/modules/hosts/hpp-1.nix
@@ -20,6 +20,9 @@
       intel-quicksync
       server
       server-apps
+      # Imported here rather than via a profile so a future move to a
+      # dedicated runner box is a one-line change. See #180.
+      github-runner
     ])
     ++ [
       {

--- a/modules/system/github-runner.nix
+++ b/modules/system/github-runner.nix
@@ -1,0 +1,90 @@
+# GitHub Actions self-hosted runner.
+#
+# Imported directly by hosts (not via the `server` profile) so a future
+# move to a dedicated runner box is a single import line. Runner
+# identity is derived from `hostSpec.hostName`, so dropping this module
+# onto another host names the systemd unit / label after that host with
+# no further edits.
+#
+# Architecture: bare-metal systemd unit (not container, not VM) — the
+# whole point of self-hosting is to share the host's warm /nix/store
+# with CI. Containerising or VMing would either bind-mount the store
+# (defeating isolation) or maintain a separate one (defeating the
+# speedup). The upstream `services.github-runners.<name>` module
+# already applies the standard systemd hardening (NoNewPrivileges,
+# ProtectSystem, PrivateDevices, ...).
+#
+# We pin an explicit `user = "github-runner"` rather than letting the
+# upstream module use DynamicUser. Reason: the runner agent invokes
+# `nix build` against the system daemon, which means the user needs to
+# appear in `nix.settings.trusted-users` to use flake settings /
+# substituters — and trusted-users is name-based. DynamicUser names
+# resolve through nss-systemd, which works but is one more moving
+# piece; a real user with a stable UID is simpler to reason about.
+#
+# PR-from-fork safety lives in the workflow (`.github/workflows/check.yml`),
+# not here: a fork PR can edit workflow YAML, so the `build` job is
+# gated with an `if:` that requires the PR head to be in this repo.
+_: {
+  flake.modules.nixos.github-runner =
+    {
+      config,
+      hostSpec,
+      ...
+    }:
+    let
+      runnerName = hostSpec.hostName;
+      runnerUser = "github-runner";
+    in
+    {
+      users.users.${runnerUser} = {
+        isSystemUser = true;
+        group = runnerUser;
+        home = "/var/lib/github-runner";
+      };
+      users.groups.${runnerUser} = { };
+
+      # Fine-grained PAT scoped to ianepreston/nixos with
+      # "Administration: Read and write" (the permission GitHub
+      # requires to mint runner registration tokens). The agent uses
+      # the PAT to fetch fresh registration tokens itself, so we don't
+      # fight the 1-hour expiry of raw registration tokens.
+      #
+      # The upstream module's ExecStartPre runs as root (via `+` prefix)
+      # and copies this file into the state dir with 0666, so the sops
+      # secret can stay root-owned 0400.
+      sops.secrets."github_runner/pat" = {
+        inherit (hostSpec) sopsFile;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+        restartUnits = [ "github-runner-${runnerName}.service" ];
+      };
+
+      services.github-runners.${runnerName} = {
+        enable = true;
+        url = "https://github.com/ianepreston/nixos";
+        tokenFile = config.sops.secrets."github_runner/pat".path;
+        user = runnerUser;
+        # Re-register an existing runner of the same name on restart
+        # (e.g. after `replace`-style PAT rotation or a state wipe).
+        replace = true;
+        extraLabels = [
+          "nixos"
+          runnerName
+        ];
+      };
+
+      # `nix build` against the system daemon needs flake / substituter
+      # settings the daemon only honours for trusted users.
+      nix.settings.trusted-users = [ runnerUser ];
+
+      # Preserve the runner's registration credentials across the
+      # impermanence wipe. Without this, the agent re-registers with
+      # GitHub on every reboot — works (PAT-based auto-registration)
+      # but churns the runner list on GitHub's side.
+      preservation.preserveAt."/persist".directories = [
+        "/var/lib/github-runner"
+      ];
+    };
+}

--- a/modules/system/github-runner.nix
+++ b/modules/system/github-runner.nix
@@ -30,6 +30,7 @@ _: {
     {
       config,
       hostSpec,
+      pkgs,
       ...
     }:
     let
@@ -81,6 +82,11 @@ _: {
           "nixos"
           runnerName
         ];
+        # The module's default PATH is minimal (bash, coreutils, git,
+        # tar, gz, nix, findutils, grep, sed, systemd) — no `ssh` or
+        # `ssh-agent`, which webfactory/ssh-agent needs to load
+        # `NIX_SECRETS_DEPLOY_KEY` for fetching the private flake input.
+        extraPackages = [ pkgs.openssh ];
       };
 
       # `nix build` against the system daemon needs flake / substituter

--- a/modules/system/github-runner.nix
+++ b/modules/system/github-runner.nix
@@ -40,7 +40,15 @@ _: {
       users.users.${runnerUser} = {
         isSystemUser = true;
         group = runnerUser;
-        home = "/var/lib/github-runner";
+        # Home is the runner's StateDirectory leaf (writable, owned by
+        # the runner user, per-instance) rather than the parent
+        # `/var/lib/github-runner`. The upstream module sets
+        # `ProtectSystem = "strict"`, which leaves only StateDirectory /
+        # WorkingDirectory / LogsDirectory writable — actions that
+        # expect `mkdir $HOME/.ssh` (webfactory/ssh-agent,
+        # actions/checkout's git-credentials helper, etc.) fail with
+        # ENOENT against an RO parent.
+        home = "/var/lib/github-runner/${runnerName}";
       };
       users.groups.${runnerUser} = { };
 


### PR DESCRIPTION
## Summary
- New `modules/system/github-runner.nix`: bare-metal `services.github-runners.<hostName>` with identity derived from `hostSpec.hostName`, explicit `user = "github-runner"` so the agent can be a nix trusted-user with a stable name, PAT from sops at `github_runner/pat`, preservation entry for `/var/lib/github-runner`.
- `modules/hosts/hpp-1.nix`: import the new module directly (not via `server` profile) so a future move to a dedicated runner host is one line.
- `.github/workflows/check.yml`: restore the `build` matrix `[hpp-1, terra]` on `[self-hosted, nixos]`, with `if:` guard so fork PRs don't get to run code on the host.

Design notes and full rationale: https://github.com/ianepreston/nixos/issues/180#issuecomment-4489680170

## Test plan
- [x] `task lint` clean
- [x] `task fmt-check` clean
- [x] `nix eval` of hpp-1 and terra toplevel drvPaths succeeds
- [x] PAT minted and stashed in sops; `nix flake update nix-secrets` brought the new key in
- [x] `task deploy:hpp-1` succeeds; `github-runner-hpp-1.service` is active and the runner appears under Settings → Actions → Runners with labels `nixos, hpp-1, linux, self-hosted`
- [ ] This PR's own `build (hpp-1)` and `build (terra)` legs go green on the self-hosted runner
- [ ] After merge: add `build (hpp-1)` and `build (terra)` to branch-protection required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)