### PR TITLE
ci: move flake-check to self-hosted runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,15 @@ concurrency:
 jobs:
   flake-check:
     name: nix flake check
-    runs-on: ubuntu-latest
+    # Self-hosted on hpp-1 — eval walks every NixOS config's drvPath,
+    # which pulls every flake input. Warm /nix/store on hpp-1 makes
+    # this seconds instead of minutes. Same fork-PR guard as the
+    # build job: workflow YAML can be edited by fork PRs and would
+    # otherwise run on our host.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, nixos]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/modules/system/github-runner.nix
+++ b/modules/system/github-runner.nix
@@ -83,10 +83,14 @@ _: {
           runnerName
         ];
         # The module's default PATH is minimal (bash, coreutils, git,
-        # tar, gz, nix, findutils, grep, sed, systemd) — no `ssh` or
-        # `ssh-agent`, which webfactory/ssh-agent needs to load
-        # `NIX_SECRETS_DEPLOY_KEY` for fetching the private flake input.
-        extraPackages = [ pkgs.openssh ];
+        # tar, gz, nix, findutils, grep, sed, systemd). Workflows need:
+        # - openssh: webfactory/ssh-agent invokes `ssh-agent` to load
+        #   NIX_SECRETS_DEPLOY_KEY for fetching the private flake input.
+        # - jq: the flake-check job pipes `nix eval --json` through it.
+        extraPackages = [
+          pkgs.openssh
+          pkgs.jq
+        ];
       };
 
       # `nix build` against the system daemon needs flake / substituter


### PR DESCRIPTION
## Summary
- `flake-check` job moves from `ubuntu-latest` to `[self-hosted, nixos]` with the same fork-PR guard as the build job.
- Adds `pkgs.jq` to the runner's `extraPackages` (the flake-check job pipes `nix eval --json` through it).

The cloud-fallback rationale from #180 was moot once branch protection required all three checks — if hpp-1 is down, nothing merges regardless. Eval walks every NixOS config's drvPath, so warm `/nix/store` on hpp-1 makes this seconds instead of ~3.5min.

## Test plan
- [x] hpp-1 deployed with jq in runner PATH before CI runs
- [ ] `nix flake check` passes on this PR running on the self-hosted runner
- [ ] Both `build hpp-1` and `build terra` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)