### PR TITLE
iot-mqtt: mosquitto broker + matter-server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,10 +493,10 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1779209645,
-        "narHash": "sha256-lH5OxyC0W1Kly0MDu/MVbzyTl84ma17fvzFwcUwoxpo=",
+        "lastModified": 1779222426,
+        "narHash": "sha256-in/n0VWgXxTP6jx6LZZTbagx7Q36P4uDv6ql/2KjyXo=",
         "ref": "main",
-        "rev": "8c5ddf02c30912aaa4afec089fe3233211e23d6d",
+        "rev": "4a768571fe69d971c1fd017e77c7202554ca1058",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/ianepreston/nix-secrets.git"

--- a/modules/apps/homeassistant.nix
+++ b/modules/apps/homeassistant.nix
@@ -56,6 +56,19 @@ _: {
       port = 8123;
     in
     {
+      # MQTT broker user. ACL grants HA full access — HA bridges every
+      # publisher's topic via its own auto-discovery prefix and re-emits
+      # state on the entity-level topics, so a narrower ACL would just
+      # mean maintaining a per-publisher list here. Operator workflow
+      # after first deploy: read the password with
+      # `task secrets:view:hpp-1` (key: homeassistant.mqtt_password) and
+      # paste it into HA's MQTT integration setup (Configuration →
+      # Devices & Services → Add Integration → MQTT; broker
+      # `10.88.0.1`, port `1883`, username `homeassistant`).
+      # configuration.yaml is operator-owned (see comment above), so the
+      # broker URL/credentials are not declaratively pushed.
+      myMosquitto.users.homeassistant.acl = [ "readwrite #" ];
+
       myAuthentik.oidcApps.homeassistant = {
         blueprintsDir = ./homeassistant-blueprints;
         clientCredsInAppEnv = false;

--- a/modules/apps/matter-server.nix
+++ b/modules/apps/matter-server.nix
@@ -1,0 +1,46 @@
+# matter-server - WebSocket Matter/Thread bridge for Home Assistant
+# Native services.matter-server from nixpkgs (DynamicUser + state at
+# /var/lib/private/matter-server). No web UI, no OIDC — it's a
+# WebSocket that HA's matter integration connects to as a client.
+#
+# Network reach: matter-server runs on the host network and binds the
+# WebSocket on `0.0.0.0:5580`. HA reaches it via the podman bridge
+# gateway at `ws://10.88.0.1:5580/ws` (HA has the default bridge NIC
+# alongside its vlan30 macvlan child — see modules/apps/homeassistant.nix).
+# The host firewall blocks 5580 on every external NIC; podman0 is in
+# trustedInterfaces (see oci-containers.nix), so this surface is only
+# loopback + the bridge in practice.
+#
+# Operator setup after first deploy: in HA, Configuration → Devices &
+# Services → Add Integration → Matter (BETA), URL
+# `ws://10.88.0.1:5580/ws`. No password — HA is the only consumer and
+# the port surface is loopback + podman bridge in practice.
+#
+# Multicast caveat: real Matter device commissioning needs IPv6 mDNS
+# reach on the IoT VLAN. The host has no IP on the `iot` netdev (only
+# HA's macvlan child does), so the matter-server process can't
+# currently see vlan30 multicast traffic. The service still comes up
+# clean without devices, and the HA integration connects via the
+# WebSocket — but actual Matter-over-IP commissioning will need
+# follow-up work (either an IP on the `iot` netdev or running
+# matter-server in a netns with macvlan reach). Deferred until Matter
+# hardware is on hand.
+_: {
+  flake.modules.nixos.matter-server = _: {
+    services.matter-server = {
+      enable = true;
+    };
+
+    preservation.preserveAt."/persist".directories = [
+      {
+        # DynamicUser puts state under /var/lib/private/<service>;
+        # the public /var/lib/matter-server is a symlink. Preserve
+        # the actual storage path (same pattern as authentik).
+        directory = "/var/lib/private/matter-server";
+        mode = "0700";
+      }
+    ];
+
+    services.restic.backups.server.paths = [ "/var/lib/private/matter-server" ];
+  };
+}

--- a/modules/profiles/server-apps.nix
+++ b/modules/profiles/server-apps.nix
@@ -57,6 +57,8 @@
         "/var/lib/kavita"
         "/var/lib/komga"
         "/var/lib/mealie"
+        "/var/lib/mosquitto"
+        "/var/lib/private/matter-server"
         "/var/lib/paperless-ngx"
         "/var/lib/pinchflat"
         "/var/lib/private/authentik"
@@ -87,6 +89,7 @@
         kavita
         komga
         maintainerr
+        matter-server
         manyfold
         mealie
         metube

--- a/modules/profiles/server.nix
+++ b/modules/profiles/server.nix
@@ -29,6 +29,7 @@
         gatus
         homepage
         mariadb
+        mosquitto
         nfsclient
         nix-maintenance
         observability

--- a/modules/system/mosquitto.nix
+++ b/modules/system/mosquitto.nix
@@ -1,0 +1,129 @@
+# Mosquitto - MQTT broker for the IoT message bus
+# Single shared broker on each server. App modules contribute users
+# (creds + ACLs) via `myMosquitto.users.<name>`, mirroring the
+# myPostgresApp / myAuthentik.oidcApps aggregator pattern:
+#
+#   myMosquitto.users.homeassistant = {
+#     acl = [ "readwrite #" ];          # HA bridges every topic
+#   };
+#   myMosquitto.users.hoymiles = {
+#     acl = [ "readwrite hoymiles/#" ];
+#   };
+#
+# Each user gets a sops secret at "<name>/mqtt_password" provisioned
+# automatically (`task secrets:secret APP=<name> KEY=mqtt_password`).
+# The upstream mosquitto module wraps each user's passwordFile through
+# `mosquitto_passwd -U` at activation so the on-disk passwd file is
+# hashed; sops just supplies the cleartext.
+#
+# Network exposure: bind to 0.0.0.0:1883 with no firewall openings.
+# The host firewall blocks the port on every external NIC; podman0 is
+# in trustedInterfaces (see oci-containers.nix), so containers on the
+# default bridge reach the broker via 10.88.0.1:1883 — same model as
+# postgres/mariadb. Apps on macvlan networks (vlan30) keep their
+# default-bridge NIC so this bridge route still applies. For ad-hoc
+# debugging, ssh into the broker host and use 127.0.0.1:1883. No
+# public Caddy route — MQTT is not an HTTP service.
+_: {
+  flake.modules.nixos.mosquitto =
+    {
+      config,
+      hostSpec,
+      lib,
+      ...
+    }:
+    let
+      apps = config.myMosquitto.users;
+    in
+    {
+      options.myMosquitto.users = lib.mkOption {
+        default = { };
+        description = ''
+          Mosquitto users contributed by app modules. Each entry
+          provisions a sops secret for the user's password and renders
+          a username/ACL pair onto the single shared listener.
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            { name, ... }:
+            {
+              options = {
+                acl = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  description = ''
+                    Mosquitto ACL strings for this user (e.g.
+                    `"readwrite hoymiles/#"`). Empty list grants the
+                    user no topics — equivalent to disabling them.
+                  '';
+                  example = [ "readwrite hoymiles/#" ];
+                };
+                secretName = lib.mkOption {
+                  type = lib.types.str;
+                  default = "${name}/mqtt_password";
+                  description = ''
+                    sops secret name for this user's password.
+                    Defaults to "<name>/mqtt_password".
+                  '';
+                };
+                username = lib.mkOption {
+                  type = lib.types.str;
+                  default = name;
+                  description = ''
+                    MQTT username. Defaults to the attribute name.
+                  '';
+                };
+              };
+            }
+          )
+        );
+      };
+
+      config = lib.mkIf (apps != { }) {
+        services.mosquitto = {
+          enable = true;
+          listeners = [
+            {
+              port = 1883;
+              # 0.0.0.0 — host firewall + tailscale0 / podman0 trust
+              # gates the actual surface (see top-of-file comment).
+              address = null;
+              users = lib.mapAttrs' (
+                _name: app:
+                lib.nameValuePair app.username {
+                  passwordFile = config.sops.secrets.${app.secretName}.path;
+                  inherit (app) acl;
+                }
+              ) apps;
+            }
+          ];
+        };
+
+        sops.secrets = lib.mapAttrs' (
+          _name: app:
+          lib.nameValuePair app.secretName {
+            inherit (hostSpec) sopsFile;
+            # mosquitto reads the file through systemd LoadCredential at
+            # activation, then re-runs mosquitto_passwd -U on the merged
+            # file. Owner=mosquitto so the LoadCredential read succeeds.
+            owner = "mosquitto";
+            restartUnits = [ "mosquitto.service" ];
+          }
+        ) apps;
+
+        # /var/lib/mosquitto/mosquitto.db is the broker's persistent
+        # session/subscription/retained-message store (binary BTree, not
+        # sqlite — no quiesce hook needed). Preserve on impermanence;
+        # back up with the rest of the server state.
+        preservation.preserveAt."/persist".directories = [
+          {
+            directory = "/var/lib/mosquitto";
+            user = "mosquitto";
+            group = "mosquitto";
+            mode = "0700";
+          }
+        ];
+
+        services.restic.backups.server.paths = [ "/var/lib/mosquitto" ];
+      };
+    };
+}

--- a/taskfiles/recovery.yaml
+++ b/taskfiles/recovery.yaml
@@ -409,6 +409,34 @@ tasks:
           SOURCE_HOST: '{{.SOURCE_HOST}}'
           SSH_PORT: '{{.SSH_PORT}}'
 
+  matter-server:
+    desc: Restore matter-server (native, DynamicUser state under /var/lib/private)
+    requires: { vars: [HOST] }
+    cmds:
+      - task: _restore-volume
+        vars:
+          HOST: '{{.HOST}}'
+          APP: matter-server
+          UNITS: 'matter-server.service'
+          PATHS: '/var/lib/private/matter-server'
+          DEST: '{{.DEST}}'
+          SOURCE_HOST: '{{.SOURCE_HOST}}'
+          SSH_PORT: '{{.SSH_PORT}}'
+
+  mosquitto:
+    desc: Restore mosquitto (native MQTT broker)
+    requires: { vars: [HOST] }
+    cmds:
+      - task: _restore-volume
+        vars:
+          HOST: '{{.HOST}}'
+          APP: mosquitto
+          UNITS: 'mosquitto.service'
+          PATHS: '/var/lib/mosquitto'
+          DEST: '{{.DEST}}'
+          SOURCE_HOST: '{{.SOURCE_HOST}}'
+          SSH_PORT: '{{.SSH_PORT}}'
+
   manyfold:
     desc: Restore manyfold (containerized + postgres)
     requires: { vars: [HOST] }
@@ -741,9 +769,11 @@ tasks:
       - task: komga
       - task: maintainerr
       - task: manyfold
+      - task: matter-server
       - task: mealie
       - task: metube
       - task: miniflux
+      - task: mosquitto
       - task: mylar3
       - task: paperless-ngx
       - task: pinchflat


### PR DESCRIPTION
## Summary
- Add `mosquitto` to the `server` profile with a new `myMosquitto.users.<name>` aggregator option (mirrors `myPostgresApp` / `myAuthentik.oidcApps`). Per-user sops-managed MQTT password + ACL.
- Add `matter-server` to `server-apps` — native service, idle until Matter devices land; HA reaches the WebSocket via the trusted podman bridge.
- HA contributes `myMosquitto.users.homeassistant` with full-ACL access.
- Recovery dispatchers + `expectedPreservedDirs` updated. `task check` passes; deployed to hpp-1 and MQTT auth verified end-to-end.

Closes #125. Follow-ups: #222 (deferred publishers: zigbee2mqtt + rtlamr2mqtt, hardware pending), #223 (matter-server vlan30 reach + sandbox DNS, blocking real Matter commissioning only).

Hoymiles is intentionally out of nix scope — HMS-WiFi inverters integrate via the `suaveolent/ha-hoymiles-wifi` HACS component talking to the inverter directly, no MQTT bridge needed.

## Test plan
- [x] `task check` (fmt, lint, `nix flake check --all-systems`)
- [x] `task deploy:hpp-1` — both services start
- [x] `mosquitto_pub -u homeassistant -P <secret>` against `127.0.0.1:1883` → succeeds
- [x] Wrong password → `Connection Refused: not authorised`
- [x] `matter-server.service` active, port 5580 listening
- [ ] HA UI: add MQTT integration (broker `10.88.0.1`, port `1883`, user `homeassistant`) — operator step
- [ ] HA UI: add Matter (BETA) with `ws://10.88.0.1:5580/ws` — operator step

🤖 Generated with [Claude Code](https://claude.com/claude-code)