### PR TITLE
snmp-exporter: read community from server-shared.yaml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,10 +493,10 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1779657761,
-        "narHash": "sha256-O3641A5MsoX0xQGBVuYXYRrZE9t4az7aDH7dxM1loA8=",
+        "lastModified": 1779740666,
+        "narHash": "sha256-+d3Yv+SWTmDfZHZ8nES8wXZQ577PKDoIU8+gkX1Km2g=",
         "ref": "main",
-        "rev": "971d5e67fe65a0286800406e3aa3b1e0e6ecd886",
+        "rev": "6d95d8d35857adfcd989e4352933b4aac93bb815",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/ianepreston/nix-secrets.git"

--- a/modules/system/snmp-exporter.nix
+++ b/modules/system/snmp-exporter.nix
@@ -36,11 +36,12 @@ _: {
   flake.modules.nixos.snmp-exporter =
     {
       config,
-      hostSpec,
+      inputs,
       pkgs,
       ...
     }:
     let
+      sopsFolder = "${inputs.nix-secrets}/sops";
       upstreamSnmpYml = builtins.readFile "${pkgs.prometheus-snmp-exporter.src}/snmp.yml";
       communityPlaceholder = config.sops.placeholder."snmp/community";
       # Both shipped auths (public_v1 and public_v2) have
@@ -53,7 +54,7 @@ _: {
     in
     {
       sops.secrets."snmp/community" = {
-        inherit (hostSpec) sopsFile;
+        sopsFile = "${sopsFolder}/server-shared.yaml";
       };
 
       # The prometheus exporters module defaults to DynamicUser=true,


### PR DESCRIPTION
## Summary

- Introduces `nix-secrets/sops/server-shared.yaml` (recipients: ipreston, ci, hpp-1, tests-vm, tests-server) as the shared decryptable surface for secrets that don't vary per server host.
- Migrates the snmp community out of `hpp-1.yaml` into the new file — first user of the pattern.
- Flips `modules/system/snmp-exporter.nix`'s `sops.secrets."snmp/community"` to point at `${sopsFolder}/server-shared.yaml` instead of `hostSpec.sopsFile`.

Cloudflare ACME (the original example in the issue body) and any future cross-host server secrets can move with the same one-line `sopsFile` flip.

## Notes

- `.sops.yaml`: the new `server-shared\.yaml$` rule has to precede the `shared\.yaml$` rule because the latter matches both filenames (sops picks the first hit). Comment in the file flags this.
- Bootstrap-script changes needed when a *new* server host comes online (auto-extending `server-shared`'s recipient list in `task bootstrap:secrets`) are captured as a comment on #244 and are out of scope here — hpp-1 is the only server today.

## Test plan

- [x] `task deploy:hpp-1 LOCAL_SECRETS=true` succeeds locally
- [x] `sops-install-secrets` decrypts on hpp-1 after rebuild
- [x] `/run/secrets.d/.../snmp.yml` contains the plaintext community in both `public_v1` and `public_v2`
- [x] `prometheus-snmp-exporter.service` active post-deploy
- [x] CI green

Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)