### PR TITLE
authentik: heal state dir ownership via ExecStartPre on migrate

### DIFF
--- a/modules/apps/authentik.nix
+++ b/modules/apps/authentik.nix
@@ -506,28 +506,45 @@
 
           # authentik-nix hardcodes DynamicUser=true across server/worker/
           # migrate (and the optional outpost units) with no exposed user
-          # override. We can't cleanly pin a static UID the way prowlarr/
-          # mealie/readeck do without `mkForce`-ing every unit and tracking
-          # the set as the flake evolves. Instead, heal the persisted
-          # state dir's ownership to whatever UID systemd allocated this
-          # boot — so a fresh `bootstrap:reinstall` against preserved
-          # /persist self-recovers. The dynamic UID is registered in NSS
-          # via nss-systemd as soon as the unit is loaded, so `id` resolves
-          # pre-start; on the very first start `id` fails and the chown
-          # is skipped (authentik creates its dir with the freshly
-          # allocated UID — fine).
-          systemd.services.authentik-state-chown = {
-            description = "Re-own /var/lib/private/authentik to the current dynamic authentik UID";
-            wantedBy = restartAuthentik;
-            before = restartAuthentik;
-            serviceConfig.Type = "oneshot";
-            script = ''
-              if uid=$(${pkgs.coreutils}/bin/id -u authentik 2>/dev/null) \
-              && gid=$(${pkgs.coreutils}/bin/id -g authentik 2>/dev/null); then
-                ${pkgs.coreutils}/bin/chown -R "$uid:$gid" /var/lib/private/authentik
-              fi
-            '';
-          };
+          # override. We can't cleanly pin a static UID without `mkForce`-ing
+          # every unit and tracking the set as the flake evolves.
+          #
+          # On systemd 258+, DynamicUser + StateDirectory mounts the state
+          # dir with `idmapped` (visible in /proc/<pid>/mountinfo). The
+          # on-disk uid stays at a fixed sentinel (nobody/65534); the
+          # kernel translates that to the dynamic uid (currently 65454)
+          # inside the unit's mount namespace, so authentik sees files as
+          # its own and writes new ones that land back at 65534 on disk.
+          # When the invariant holds, no chown is needed.
+          #
+          # The hazard is stale state that pre-dates the idmap or got
+          # rewritten outside the idmapped mount: files literally owned
+          # by 65454 on disk (which is what authentik saw under earlier
+          # systemd, or what a `chown -R authentik` run from the host's
+          # mount namespace would write). uid 65454 on disk has no reverse
+          # mapping, so the kernel surfaces it as the overflow uid (nobody)
+          # inside the namespace, and authentik can't write to its own
+          # prometheus counters — the failure mode that took hpp-1 down
+          # on May 27. The previous `authentik-state-chown` unit was
+          # supposed to heal this but ran `Before=authentik.service`
+          # (when nss-systemd has no record of the dynamic user), so
+          # `id authentik` failed, the guarding `if` silently skipped,
+          # and the unit reported success.
+          #
+          # ExecStartPre runs inside the unit's mount namespace after
+          # systemd has set up the idmap and registered the dynamic uid
+          # with nss-systemd. `chown authentik:authentik` through the
+          # idmapped mount writes the on-disk sentinel uid back, healing
+          # any stale 65454 inodes in place. The `+` prefix runs as root
+          # so the chown can cross arbitrary ownership boundaries. Migrate
+          # runs Before=server/worker, so healing here covers the stack;
+          # a chown failure now fails the unit and blocks ExecStart
+          # instead of silently letting authentik come up wedged.
+          systemd.services.authentik-migrate.serviceConfig.ExecStartPre = [
+            "+${pkgs.writeShellScript "authentik-state-chown" ''
+              ${pkgs.coreutils}/bin/chown -R authentik:authentik /var/lib/private/authentik
+            ''}"
+          ];
 
           # Real readiness boundary for the authentik stack. The three
           # native units (server / worker / migrate) are all Type=simple,


### PR DESCRIPTION
## Summary

Replaces the standalone `authentik-state-chown.service` with a `+`-prefixed `ExecStartPre` on `authentik-migrate.service`. Fixes the May 27 gatus-503 cascade on hpp-1, where forward-auth-gated apps started returning 503 ~20s after a deploy-driven authentik restart.

## What was actually happening

On systemd 258+, DynamicUser + StateDirectory mounts the state dir with `idmapped` (visible in `/proc/<pid>/mountinfo`). The on-disk uid stays at a fixed sentinel (nobody/65534); the kernel translates that to the dynamic uid (currently 65454) inside the unit's mount namespace, so authentik sees files as its own and writes new ones that land back at 65534 on disk. When the invariant holds, no chown is needed.

The hazard is **stale state with literal 65454 burned into the inodes on disk** — what authentik wrote under earlier systemd before idmapped mounts, or what a `chown -R authentik` from the host's mount namespace would produce. uid 65454 on disk has no reverse mapping, so the kernel surfaces it as the overflow uid (nobody) inside the namespace, and authentik can't write to its own prometheus counters. Every Django request then 500s in the prometheus middleware → gunicorn looks dead → Caddy's forward-auth probe returns 5xx → every gated app surfaces 503 to gatus.

The previous `authentik-state-chown.service` was meant to heal this but ran `Before=authentik.service`, where nss-systemd has no record of the dynamic user. `id authentik` returned non-zero, the guarding `if` silently skipped the chown, and the unit reported success — silent for a week. Daily error counts on hpp-1: 1 on May 20 (one-off blip when LDAP outpost first deployed), 0 from May 21–26, **9800** on May 27 starting 20s after a deploy-driven authentik restart, **23170+** through the morning of May 28.

## The fix

`ExecStartPre` on `authentik-migrate.service` runs inside the unit's mount namespace after systemd has set up the idmap and registered the dynamic uid with nss-systemd. `chown authentik:authentik` through the idmapped mount writes the on-disk sentinel uid back, healing any stale 65454 inodes in place. The `+` prefix runs as root so the chown can cross arbitrary ownership boundaries. Migrate runs `Before=` server/worker, so healing here covers the whole stack. A chown failure now fails the unit and blocks ExecStart instead of silently letting authentik come up wedged.

## Test plan

- [x] `task check` passes
- [x] `nix build .#nixosConfigurations.hpp-1.config.system.build.toplevel` succeeds
- [x] Built unit file shows our chown ordered first in ExecStartPre, standalone unit gone
- [x] `task deploy:hpp-1` — chown runs, `/-/health/ready/` returns 200, forward-auth apps return 302, 0 `Permission denied` since deploy
- [x] `sudo systemctl reboot` on hpp-1 — comes back healthy, idmapped mount visible in mountinfo, on-disk uid stays at the 65534 sentinel as expected, 0 perm errors, forward-auth working
- [x] `task deploy:amos1` — same verification, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)