### PR TITLE
authentik: set embedded outpost authentik_host in blueprint

### DIFF
--- a/modules/apps/authentik.nix
+++ b/modules/apps/authentik.nix
@@ -128,6 +128,18 @@
         n: "- !Find [authentik_providers_proxy.proxyprovider, [name, ${n}]]"
       ) fwAppNames;
 
+      # `config.authentik_host` is the base URL the outpost uses to reach
+      # the authentik server; `authentik_host_browser` is the base URL
+      # the outpost emits in 302 Location headers for unauthenticated
+      # requests. With both unset, the outpost falls back to its bind
+      # address (http://0.0.0.0:9000), which a browser can't resolve
+      # and which leaks an HTTP hop into otherwise-HTTPS auth flows.
+      # The default has been silently broken on every fresh authentik
+      # install — hpp-1 only worked because the field was set by hand
+      # in the UI before this blueprint existed. Encoding it here makes
+      # forward-auth deterministic across hosts (and incidentally lets
+      # gatus's external probes follow the redirect over HTTPS, so the
+      # cert-expiration condition succeeds).
       outpostEntry = ''
         - model: authentik_outposts.outpost
           identifiers:
@@ -135,7 +147,10 @@
           attrs:
             type: proxy
             providers:
-              ${outpostProviders}'';
+              ${outpostProviders}
+            config:
+              authentik_host: https://authentik.${hostSpec.serverDomain}
+              authentik_host_browser: https://authentik.${hostSpec.serverDomain}'';
 
       fwBlueprintContent = ''
         version: 1


### PR DESCRIPTION
## Summary

Encodes `authentik_host` and `authentik_host_browser` on the embedded outpost in the forward-auth blueprint, parameterized by `hostSpec.serverDomain`. Fixes broken forward-auth redirects on amos1 (and any future host) without depending on out-of-band UI clicks.

## What was broken

The embedded outpost generates 302 Location headers for unauthenticated forward-auth requests using `config.authentik_host_browser`, falling back to `authentik_host`, falling back to its bind address. With both unset — the default on a fresh authentik install — the outpost emits `http://0.0.0.0:9000/...`, which browsers can't resolve and which leaks a plaintext hop into otherwise-HTTPS auth flows. **Forward-auth has been silently broken for real users on amos1 since install** — nobody noticed because nobody had tried to log into a gated app there yet.

hpp-1 only worked because someone (you, at some point in the past) set `authentik_host` by hand in the UI before this blueprint existed. The outpost config dump confirmed the diff:

```diff
hpp-1: "authentik_host": "https://authentik.dnix.ipreston.net"
amos1: "authentik_host": ""
```

The visible symptom was gatus alerting on `CERTIFICATE_EXPIRATION = 0s` for every forward-auth app on amos1 — gatus follows the 302 into `http://0.0.0.0:9000`, which has no TLS, so the cert-expiration condition fails. But that's downstream of the real bug.

## The fix

Adds `config.authentik_host` and `config.authentik_host_browser` to the existing `outpostEntry` blueprint. Per-host `hostSpec.serverDomain` keeps it deterministic. After this, a `bootstrap:reinstall` of any host comes up with working forward-auth out of the box, no UI intervention needed.

## Caveat about `attrs.config`

Setting `attrs.config` in a blueprint replaces the entire JSONField — only the two keys we set survive in the persisted config. Other keys (`log_level`, `refresh_interval`, `authentik_host_insecure`, `object_naming_template`, `kubernetes_*`, `docker_*`) fall back to the dataclass defaults in `authentik.outposts.models.OutpostConfig`, which happen to match the values that were being persisted (`info`, `minutes=5`, `false`, `ak-outpost-%(name)s`, …). No behavior change observed on either host post-deploy.

If we ever need to customize one of those other fields, we'd have to add it to the blueprint explicitly — there's no merge.

## Test plan

- [x] `task check` passes
- [x] `task deploy:amos1` — redirect Location now `https://authentik.amos.ipreston.net/...` (was `http://0.0.0.0:9000/...`), API config dump confirms both fields set, no errors/warnings post-blueprint-apply
- [x] `task deploy:hpp-1` — redirect unchanged at `https://authentik.dnix.ipreston.net/...` (already set via UI), still healthy
- [x] gatus on both hosts: all forward-auth probes green (amos1 was 18 failing, now 0; only the unrelated `homeassistant: 502` remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)