### PR TITLE
upgrade to nixos 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779795654,
-        "narHash": "sha256-VqF1ueagt1+b1e6mrJ5+rs9dk3OcINxtwZgbAg6suUI=",
+        "lastModified": 1780149860,
+        "narHash": "sha256-SpGXJc7A6DxqpWo88d5Awyhl4xOnGFsv76y8ZmjAvmA=",
         "owner": "nix-community",
         "repo": "authentik-nix",
-        "rev": "88a8771c30c0663e4789fac67fa415e7d5554715",
+        "rev": "bf3c780157449d75ac8dfc184963d57d23f59e8c",
         "type": "github"
       },
       "original": {
@@ -47,16 +47,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778615640,
-        "narHash": "sha256-tTBGwajdtEPuk36va5HgnnqR8sTuSwIt/c48bIinRlA=",
+        "lastModified": 1779980524,
+        "narHash": "sha256-FF44QGa0FBQACAcY7KmUdkpJuIVRNTyje1vxkQu8enM=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "095e2897d52397962d153be2d689cedcdb71906c",
+        "rev": "d7dedc86d2f59bf958ee03c39f2cc3618347ea2f",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2026.2.3",
+        "ref": "version/2026.2.4",
         "repo": "authentik",
         "type": "github"
       }
@@ -402,16 +402,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1779726825,
+        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -464,16 +464,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
         "owner": "nix-darwin",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -529,16 +529,16 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1779975975,
-        "narHash": "sha256-gvG59uDld9KrCg6rD9eQtGGGUbKNf51dngL5SPB/xng=",
+        "lastModified": 1780020239,
+        "narHash": "sha256-ik+V883hTc6GG7TzjxMdhEoMV0hCbQPfsRtNsB1qWUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d66785aca79f0b08eb560a82672f55859af59ca",
+        "rev": "c85dc29a9bcafa665b8ce0654ca019cdb05e63c6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -560,16 +560,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1779971959,
+        "narHash": "sha256-R5nauXyqyfRUFiZycFFZdkF7wl6eaUpPLst35+2nJQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -605,16 +605,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1779971959,
+        "narHash": "sha256-R5nauXyqyfRUFiZycFFZdkF7wl6eaUpPLst35+2nJQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,22 +9,25 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     import-tree.url = "github:vic/import-tree";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     # The next two are for pinning to stable vs unstable regardless of what the above is set to
     # This is particularly useful when an upcoming stable release is in beta because you can effectively
     # keep 'nixpkgs-stable' set to stable for critical packages while setting 'nixpkgs' to the beta branch to
     # get a jump start on deprecation changes.
     # See also 'stable-packages' and 'unstable-packages' overlays at 'overlays/default.nix"
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nix-darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs-darwin";
     hardware.url = "github:nixos/nixos-hardware";
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # stylix has no release-26.05 branch yet — pinned to 25.11 release branch.
+    # Stylix pins its own nixpkgs internally, so the lag mostly affects whether
+    # its HM/NixOS module APIs still match. Bump when upstream tags it.
     stylix.url = "github:danth/stylix/release-25.11";
     nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=latest";
     # Declarative partitioning and formatting

--- a/modules/desktop/gnome.nix
+++ b/modules/desktop/gnome.nix
@@ -9,10 +9,7 @@
     {
       services = {
         gnome.gcr-ssh-agent.enable = false;
-        displayManager.gdm = {
-          enable = true;
-          wayland = true;
-        };
+        displayManager.gdm.enable = true;
         desktopManager.gnome.enable = true;
         xserver = {
           enable = true;

--- a/modules/programs/browser.nix
+++ b/modules/programs/browser.nix
@@ -3,6 +3,11 @@
 _: {
   flake.modules.homeManager.browser = _: {
     programs.firefox.enable = true;
+    # HM 26.05 changed the default to `$XDG_CONFIG_HOME/mozilla/firefox`.
+    # Pin to the legacy path explicitly — `home.stateVersion = 25.05` would
+    # do this implicitly, but the explicit set silences the migration
+    # warning. Switch to the XDG path is a separate, on-disk migration.
+    programs.firefox.configPath = ".mozilla/firefox";
     xdg.mimeApps.defaultApplications = {
       "text/html" = [ "firefox.desktop" ];
       "x-scheme-handler/http" = [ "firefox.desktop" ];

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -16,6 +16,9 @@ _: {
         # Often required; don't worry as they are isolated in Neovim environment
         withPython3 = true;
         withNodeJs = true;
+        # Default in HM 26.05 is `false`; set explicitly to silence the
+        # `home.stateVersion < 26.05` migration warning.
+        withRuby = true;
 
         # Packages available within Neovim during runtime. Put your LSP Servers, formatters, linters, etc.
         extraPackages = with pkgs; [
@@ -58,16 +61,25 @@ _: {
         ];
       };
 
-      # Symlink your Neovim configuration (or delete the line to manage .config/nvim directly)
-      xdg.configFile."nvim".source =
-        config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/nixos/modules/programs/neovim";
+      # Symlink your Neovim configuration (or delete the line to manage .config/nvim directly).
+      # As of HM 26.05, the upstream `programs.neovim` module always emits
+      # `xdg.configFile."nvim/init.lua"` (even just to set
+      # `vim.g.loaded_*_provider=0`). That child entry collides with this
+      # whole-directory symlink in the home-manager-files build (the install
+      # script checks every target stays under $HOME after realpath). Force
+      # the child off so only our symlink survives.
+      xdg.configFile = {
+        "nvim".source =
+          config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/nixos/modules/programs/neovim";
+        "nvim/init.lua".enable = lib.mkForce false;
 
-      # Make yamlfmt not fight with yamllint
-      xdg.configFile."yamlfmt/.yamlfmt".text = ''
-        formatter:
-          type: basic
-          include_document_start: true
-      '';
+        # Make yamlfmt not fight with yamllint
+        "yamlfmt/.yamlfmt".text = ''
+          formatter:
+            type: basic
+            include_document_start: true
+        '';
+      };
       # Tools available during activation
       home.extraActivationPath = with pkgs; [
         git

--- a/modules/system/_hm-core/packages.nix
+++ b/modules/system/_hm-core/packages.nix
@@ -18,7 +18,7 @@ in
     ripgrep
     fd
     lazygit
-    neofetch
+    fastfetch
     jq
     openssl
     go-task

--- a/modules/system/grafana.nix
+++ b/modules/system/grafana.nix
@@ -97,6 +97,13 @@ _: {
             # path at runtime, so the password never lands in the
             # rendered grafana.ini in /nix/store.
             admin_password = "$__file{${config.sops.secrets."grafana/bootstrap_password".path}}";
+            # 26.05 drops the upstream default for `secret_key`. Pinning
+            # the historical default keeps any DB-encrypted material in
+            # /var/lib/grafana/grafana.db readable across the upgrade.
+            # Datasources/dashboards here are file-provisioned, so the
+            # only material protected by this key is incidental — no
+            # special protection needed, no rotation required.
+            secret_key = "SW2YcwTIb9zpOOhoPsMm"; # pragma: allowlist secret
           };
           # OIDC against Authentik. `role_attribute_path` is JMESPath
           # over the id_token claims — `Infrastructure` group → Admin,


### PR DESCRIPTION
Bumps nixpkgs / nix-darwin / home-manager to release-26.05 (and the matching authentik patch). Stylix stays on release-25.11 — upstream hasn't tagged a 26.05 branch yet (#261).

Module fixups required by the jump:

- gnome.nix: drop `services.displayManager.gdm.wayland` — wayland is the GDM default now.
- neovim.nix: set `withRuby = true` explicitly (HM 26.05 default is false; silences the stateVersion migration warning) and force-disable the upstream-emitted `xdg.configFile."nvim/init.lua"` child entry so it doesn't collide with our whole-`nvim` symlink in the HM build.
- _hm-core/packages.nix: neofetch → fastfetch (neofetch dropped upstream).
- grafana.nix: pin `settings.security.secret_key` to the historical default. 26.05 removed the default; pinning it keeps existing DB-encrypted material readable across the upgrade. Datasources / dashboards here are file-provisioned, so the material protected by this key is incidental — no rotation needed.
- browser.nix: pin firefox `configPath = ".mozilla/firefox"` (HM 26.05 default flipped to `$XDG_CONFIG_HOME/mozilla/firefox`); explicit set silences the warning, on-disk migration is deferred.

Deployed to hpp-1 and amos1; terra picked it up via local rebuild. All hosts came up clean post-reboot with authentik 2026.2.4 migrations applied and every app service active.

Follow-up: HM `programs.ssh.matchBlocks` → `programs.ssh.settings` migration tracked in #260.