### PR TITLE
ssh: migrate home-manager matchBlocks → settings

### DIFF
--- a/modules/system/ssh-homelan.nix
+++ b/modules/system/ssh-homelan.nix
@@ -3,32 +3,28 @@
 _: {
   flake.modules.homeManager.ssh-homelan = _: {
     programs.ssh = {
-      matchBlocks = {
+      settings = {
         "switch" = {
-          hostname = "192.168.10.2";
-          user = "admin";
-          extraOptions = {
-            "KexAlgorithms" = "+diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1";
-            "PubkeyAcceptedKeyTypes" = "+ssh-rsa";
-            "HostKeyAlgorithms" = "+ssh-rsa";
-            "Ciphers" = "+3des-cbc";
-          };
+          HostName = "192.168.10.2";
+          User = "admin";
+          KexAlgorithms = "+diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1";
+          PubkeyAcceptedKeyTypes = "+ssh-rsa";
+          HostKeyAlgorithms = "+ssh-rsa";
+          Ciphers = "+3des-cbc";
         };
         "behemoth" = {
-          hostname = "192.168.10.1";
-          user = "admin";
-          port = 2222;
+          HostName = "192.168.10.1";
+          User = "admin";
+          Port = 2222;
         };
         "laconia" = {
-          hostname = "laconia.ipreston.net";
-          user = "ipreston";
-          port = 2222;
-          extraOptions = {
-            "RequestTTY" = "yes";
-            "RemoteCommand" = "TERM=xterm-256color bash -l";
-            "IgnoreUnknown" = "WarnWeakCrypto";
-            "WarnWeakCrypto" = "no-pq-kex";
-          };
+          HostName = "laconia.ipreston.net";
+          User = "ipreston";
+          Port = 2222;
+          RequestTTY = "yes";
+          RemoteCommand = "TERM=xterm-256color bash -l";
+          IgnoreUnknown = "WarnWeakCrypto";
+          WarnWeakCrypto = "no-pq-kex";
         };
       };
     };

--- a/modules/system/ssh.nix
+++ b/modules/system/ssh.nix
@@ -42,18 +42,18 @@
     programs.ssh = {
       enable = true;
       enableDefaultConfig = false;
-      matchBlocks = {
+      settings = {
         "*" = {
-          forwardAgent = false;
-          addKeysToAgent = "no";
-          compression = false;
-          serverAliveInterval = 0;
-          serverAliveCountMax = 3;
-          hashKnownHosts = false;
-          userKnownHostsFile = "~/.ssh/known_hosts";
-          controlMaster = "no";
-          controlPath = "~/.ssh/master-%r@%n:%p";
-          controlPersist = "no";
+          ForwardAgent = false;
+          AddKeysToAgent = "no";
+          Compression = false;
+          ServerAliveInterval = 0;
+          ServerAliveCountMax = 3;
+          HashKnownHosts = false;
+          UserKnownHostsFile = "~/.ssh/known_hosts";
+          ControlMaster = "no";
+          ControlPath = "~/.ssh/master-%r@%n:%p";
+          ControlPersist = "no";
         };
       };
     };


### PR DESCRIPTION
## Summary
- Migrate `programs.ssh.matchBlocks` + per-block `extraOptions` to `programs.ssh.settings.<host>.<DirectiveName>` (HM 26.05 deprecation)
- `modules/system/ssh.nix`: `*` defaults moved over, all directives renamed to OpenSSH directive names (`forwardAgent` → `ForwardAgent`, etc.)
- `modules/system/ssh-homelan.nix`: per-host blocks (`switch`, `behemoth`, `laconia`) inlined — `extraOptions` dropped, `hostname`/`user`/`port` → `HostName`/`User`/`Port`

## Verification
- `nix flake check --all-systems` clean; previously emitted ssh deprecation warnings gone on terra, hpp-1, xps13 evals.
- Rendered `~/.ssh/config` before vs. after diff: identical directive set, only alphabetic reordering (HM's new code path sorts via `lib.attrNames`). `IgnoreUnknown` correctly emitted first inside `Host laconia` (the module's special-case logic preserves OpenSSH ordering semantics).
- Applied locally on terra via `task rebuild`:
  - `ssh behemoth uname -a` → connects on Port 2222 as admin ✓
  - `ssh switch` → reaches HP ProCurve banner (legacy KEX/Ciphers/HostKeyAlgorithms negotiate cleanly) ✓
  - `ssh laconia` → `RemoteCommand` active (errors as expected when also passing a CLI cmd); `-o RemoteCommand=none` shell opens as ipreston on Port 2222 ✓

Closes #260

## Test plan
- [x] eval terra + hpp-1 + xps13 — no SSH warnings
- [x] rendered ssh config diff = directive parity
- [x] ssh switch / behemoth / laconia from terra
- [ ] auto-upgrade rolls out to xps13 / luna / amos1 / penguin / hpp-1 on their timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)