### PR TITLE
Bump caddy cloudflare-dns plugin closure hash

### DIFF
--- a/modules/system/caddy.nix
+++ b/modules/system/caddy.nix
@@ -74,7 +74,7 @@ _: {
               # renovate: datasource=github-tags depName=caddy-dns/cloudflare
               "github.com/caddy-dns/cloudflare@v0.2.4"
             ];
-            hash = "sha256-vNSHU7txQLs0m0UChuszURXjEoMj4r1902+1ei0/DaI=";
+            hash = "sha256-bzMqxWTqrJ1skZmRTXyEMCKStXpljbqe5r0Ve2cnBfM=";
           };
           globalConfig = ''
             acme_dns cloudflare {env.CLOUDFLARE_API_TOKEN}


### PR DESCRIPTION
## Summary

- The cloudflare-dns plugin closure hash in `modules/system/caddy.nix` was stale (`vNSHU7…`); the actual closure now hashes to `bzMqxWTq…`, so every host build was failing with a fixed-output hash mismatch
- Plugin version (`v0.2.4`) is unchanged — just refreshing the hash that renovate left behind on the last bump

## Test plan

- [x] `nix build .#nixosConfigurations.hpp-1.config.services.caddy.package` succeeds
- [ ] Merge unblocks local builds / `task deploy:<host>` flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)