### PR TITLE
Move sabnzbd incomplete dir to local SSD + add stale/size alerts

### DIFF
--- a/modules/apps/sabnzbd.nix
+++ b/modules/apps/sabnzbd.nix
@@ -28,6 +28,7 @@ _: {
     {
       config,
       hostSpec,
+      pkgs,
       ...
     }:
     let
@@ -36,6 +37,17 @@ _: {
       sabnzbdUser = "server-${hostSpec.serverEnvironment}";
       serverUid = config.users.users.${sabnzbdUser}.uid;
       serverGid = config.users.groups.servers.gid;
+      # incomplete/ lives on the local SSD, not the NFS share. par2
+      # verify and unrar then read it back without bouncing TLS-wrapped
+      # NFS RX against simultaneous NFS TX. Sibling of /var/lib/sabnzbd
+      # so it's NOT pulled into restic (restic snapshots /var/lib/sabnzbd
+      # only). Preserved via /persist (bind mount below) but ephemeral
+      # in intent — partial downloads aren't worth keeping across reboots
+      # except for in-flight resume. See #276.
+      incompleteDir = "/var/lib/sabnzbd-incomplete";
+      # Textfile collector — set in modules/system/victoriametrics.nix.
+      # Kept in sync by hand; both modules live on the same hosts.
+      textfileDir = "/var/lib/node-exporter-textfile-collector";
       appriseConfigDir = "/var/lib/containers/apprise/config";
       appriseConfigFile = "${appriseConfigDir}/sabnzbd.yml";
       # Apprise URL pointing the local apprise lib at our apprise-api
@@ -83,6 +95,27 @@ _: {
             host = "0.0.0.0";
             inherit port;
             host_whitelist = "${sabnzbdHost},host.containers.internal";
+            # Incomplete on local SSD; finished media gets renamed onto
+            # the NFS share by sabnzbd's post-processing step. See #276
+            # for the throughput story (par2 + direct_unpack reading
+            # incomplete back over NFS was eating ~30 MB/s on amos1).
+            download_dir = incompleteDir;
+          };
+          # Codified per-account connection caps (#276). The .ini is
+          # writable (allowConfigWrite=true on stateVersion<26.05), so
+          # operator-side tuning sticks, but the canonical value lives
+          # here so a fresh deploy doesn't silently revert to the
+          # provider's default. Only `connections` is set here; other
+          # fields (port, ssl, credentials) come from the on-disk ini
+          # via the module's preStart merge.
+          servers."news.frugalusenet.com" = {
+            name = "news.frugalusenet.com";
+            displayname = "news.frugalusenet.com";
+            host = "news.frugalusenet.com";
+            # ~50 saturates frugal's per-account throughput ceiling
+            # (~40-50 MB/s); past that, extra conns just pay TLS
+            # overhead without adding bandwidth. See the issue thread.
+            connections = 50;
           };
           apprise = {
             apprise_enable = 1;
@@ -94,6 +127,16 @@ _: {
       preservation.preserveAt."/persist".directories = [
         {
           directory = "/var/lib/sabnzbd";
+          user = sabnzbdUser;
+          group = "servers";
+          mode = "0700";
+        }
+        # Incomplete dir: bind-mounted from /persist so partial downloads
+        # survive a reboot (sabnzbd resumes them on start). Not added to
+        # `restic.backups.server.paths` — there's nothing worth a backup
+        # in a half-finished NZB unpack.
+        {
+          directory = incompleteDir;
           user = sabnzbdUser;
           group = "servers";
           mode = "0700";
@@ -115,46 +158,124 @@ _: {
         restartUnits = [ "apprise-sabnzbd-config.service" ];
       };
 
-      systemd.services.apprise-sabnzbd-config = {
-        description = "Render apprise stateful config for sabnzbd";
-        wantedBy = [ "multi-user.target" ];
-        before = [ "podman-apprise.service" ];
-        # Explicit ordering on the sops decryption unit
-        # (sops.useSystemdActivation = true in modules/system/sops.nix).
-        # Without this, EnvironmentFile= points at
-        # /run/secrets/rendered/apprise-sabnzbd.env before sops has
-        # rendered the template, the unit fails with "Failed to load
-        # environment files", and only the sops template's restartUnits
-        # hook (which fires after rendering) recovers it ~minutes later.
-        # See #194. ConditionPathExists below belt-and-suspenders the
-        # case where sops *finishes* but this specific render failed.
-        after = [ "sops-install-secrets.service" ];
-        wants = [ "sops-install-secrets.service" ];
-        unitConfig.ConditionPathExists = config.sops.templates."apprise-sabnzbd.env".path;
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          EnvironmentFile = config.sops.templates."apprise-sabnzbd.env".path;
+      systemd = {
+        # Make sure incompleteDir exists before sabnzbd starts (the
+        # preservation bind-mount creates the path, but only on
+        # impermanence hosts; tmpfiles covers the non-impermanent case
+        # and pins ownership either way).
+        tmpfiles.rules = [
+          "d ${incompleteDir} 0700 ${sabnzbdUser} servers - -"
+        ];
+
+        services = {
+          # Publish two textfile-collector metrics for #276's alerts:
+          #   sabnzbd_incomplete_oldest_seconds — age of the oldest file
+          #     in the incomplete dir. >24h is a stalled download /
+          #     wedged post-processor / forgotten paused queue.
+          #   sabnzbd_incomplete_dir_bytes — total size of the incomplete
+          #     dir. Threshold rule in modules/system/victoriametrics.nix
+          #     covers the "shared with /persist, no dedicated mount" case
+          #     (issue's option (a/b), not (c)).
+          # Atomic write via tempfile + rename so a crashed run never
+          # leaves a partial `.prom` for node_exporter to scrape.
+          sabnzbd-incomplete-metrics = {
+            description = "publish sabnzbd incomplete-dir metrics to node_exporter textfile collector";
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              Environment = [
+                "INCOMPLETE_DIR=${incompleteDir}"
+                "OUT=${textfileDir}/sabnzbd.prom"
+                "PATH=${
+                  pkgs.lib.makeBinPath [
+                    pkgs.coreutils
+                    pkgs.findutils
+                    pkgs.gawk
+                  ]
+                }"
+              ];
+            };
+            script = ''
+              set -eu
+              oldest=0
+              if [ -d "$INCOMPLETE_DIR" ]; then
+                oldest_mtime=$(find "$INCOMPLETE_DIR" -type f -printf '%T@\n' 2>/dev/null | sort -n | head -1 || true)
+                if [ -n "$oldest_mtime" ]; then
+                  now=$(date +%s)
+                  oldest=$(awk -v now="$now" -v t="$oldest_mtime" 'BEGIN { printf "%d", now - t }')
+                fi
+              fi
+              bytes=$(du -sb "$INCOMPLETE_DIR" 2>/dev/null | awk '{print $1}')
+              : ''${bytes:=0}
+              tmp=$(mktemp -p "$(dirname "$OUT")" .sabnzbd.prom.XXXXXX)
+              {
+                echo "# HELP sabnzbd_incomplete_oldest_seconds Age in seconds of the oldest file under sabnzbd's incomplete dir."
+                echo "# TYPE sabnzbd_incomplete_oldest_seconds gauge"
+                echo "sabnzbd_incomplete_oldest_seconds $oldest"
+                echo "# HELP sabnzbd_incomplete_dir_bytes Total bytes under sabnzbd's incomplete dir."
+                echo "# TYPE sabnzbd_incomplete_dir_bytes gauge"
+                echo "sabnzbd_incomplete_dir_bytes $bytes"
+              } > "$tmp"
+              chmod 0644 "$tmp"
+              mv "$tmp" "$OUT"
+            '';
+          };
+
+          apprise-sabnzbd-config = {
+            description = "Render apprise stateful config for sabnzbd";
+            wantedBy = [ "multi-user.target" ];
+            before = [ "podman-apprise.service" ];
+            # Explicit ordering on the sops decryption unit
+            # (sops.useSystemdActivation = true in modules/system/sops.nix).
+            # Without this, EnvironmentFile= points at
+            # /run/secrets/rendered/apprise-sabnzbd.env before sops has
+            # rendered the template, the unit fails with "Failed to load
+            # environment files", and only the sops template's restartUnits
+            # hook (which fires after rendering) recovers it ~minutes later.
+            # See #194. ConditionPathExists below belt-and-suspenders the
+            # case where sops *finishes* but this specific render failed.
+            after = [ "sops-install-secrets.service" ];
+            wants = [ "sops-install-secrets.service" ];
+            unitConfig.ConditionPathExists = config.sops.templates."apprise-sabnzbd.env".path;
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              EnvironmentFile = config.sops.templates."apprise-sabnzbd.env".path;
+            };
+            script = ''
+              set -e
+              install -d -m 0750 -o ${toString serverUid} -g ${toString serverGid} ${appriseConfigDir}
+              umask 027
+              # Apprise needs Discord webhooks in discord://ID/TOKEN form,
+              # not the raw https URL stored in sops (which alertmanager
+              # consumes directly). Discord accepts (and pastes from its UI)
+              # both discord.com and the legacy discordapp.com hostnames, so
+              # strip either prefix — the second expansion is a no-op when
+              # the first matched.
+              discord_path="''${DISCORD_WEBHOOK#https://discord.com/api/webhooks/}"
+              discord_path="''${discord_path#https://discordapp.com/api/webhooks/}"
+              cat > ${appriseConfigFile} <<EOF
+              urls:
+                - discord://$discord_path
+              EOF
+              chown ${toString serverUid}:${toString serverGid} ${appriseConfigFile}
+              chmod 0640 ${appriseConfigFile}
+            '';
+          };
         };
-        script = ''
-          set -e
-          install -d -m 0750 -o ${toString serverUid} -g ${toString serverGid} ${appriseConfigDir}
-          umask 027
-          # Apprise needs Discord webhooks in discord://ID/TOKEN form,
-          # not the raw https URL stored in sops (which alertmanager
-          # consumes directly). Discord accepts (and pastes from its UI)
-          # both discord.com and the legacy discordapp.com hostnames, so
-          # strip either prefix — the second expansion is a no-op when
-          # the first matched.
-          discord_path="''${DISCORD_WEBHOOK#https://discord.com/api/webhooks/}"
-          discord_path="''${discord_path#https://discordapp.com/api/webhooks/}"
-          cat > ${appriseConfigFile} <<EOF
-          urls:
-            - discord://$discord_path
-          EOF
-          chown ${toString serverUid}:${toString serverGid} ${appriseConfigFile}
-          chmod 0640 ${appriseConfigFile}
-        '';
+
+        timers.sabnzbd-incomplete-metrics = {
+          description = "Periodic sabnzbd incomplete-dir metrics refresh";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            # 5m matches the SabnzbdIncompleteStale `for: 30m` window —
+            # plenty of samples to debounce, low enough to surface a
+            # newly-stalled download within an hour.
+            OnBootSec = "2m";
+            OnUnitActiveSec = "5m";
+            AccuracySec = "30s";
+          };
+        };
       };
 
     };

--- a/modules/profiles/dev-server-apps.nix
+++ b/modules/profiles/dev-server-apps.nix
@@ -66,6 +66,7 @@
         "/var/lib/radarr"
         "/var/lib/readeck"
         "/var/lib/sabnzbd"
+        "/var/lib/sabnzbd-incomplete"
         "/var/lib/sonarr"
         # Container app whose volumes live OUTSIDE /var/lib/containers:
         # the upstream unifi-os-server flake module defaults its

--- a/modules/profiles/prod-server-apps.nix
+++ b/modules/profiles/prod-server-apps.nix
@@ -64,6 +64,7 @@
         "/var/lib/radarr"
         "/var/lib/readeck"
         "/var/lib/sabnzbd"
+        "/var/lib/sabnzbd-incomplete"
         "/var/lib/sonarr"
         # Container app whose volumes live OUTSIDE /var/lib/containers:
         # the upstream unifi-os-server flake module defaults its

--- a/modules/system/victoriametrics.nix
+++ b/modules/system/victoriametrics.nix
@@ -167,6 +167,42 @@ _: {
                 };
               }
               {
+                # Stale file under sabnzbd's incomplete dir (#276).
+                # Metric is published by the sabnzbd-incomplete-metrics
+                # oneshot in modules/apps/sabnzbd.nix every 5m. >24h
+                # means a download is stalled (missing articles across
+                # all configured providers, post-processing wedged, or
+                # the queue is paused and forgotten). Absent on hosts
+                # that don't run sabnzbd — `for: 30m` debounces the gap
+                # between the oneshot's first write and node_exporter's
+                # next scrape.
+                alert = "SabnzbdIncompleteStale";
+                expr = "sabnzbd_incomplete_oldest_seconds > 86400";
+                for = "30m";
+                labels.severity = "warning";
+                annotations = {
+                  summary = "sabnzbd has a stale file in incomplete/ on {{ $labels.instance }}";
+                  description = "A file under sabnzbd's incomplete dir has been there for >24h ({{ $value | humanizeDuration }}). Stalled download, wedged post-processing, or forgotten paused queue.";
+                };
+              }
+              {
+                # Incomplete dir filling up (#276). The dir lives under
+                # /persist, sharing the root filesystem — the existing
+                # FilesystemAlmostFull rule (above) covers truly-full
+                # /persist, but a stuck unrar can chew through 100s of
+                # GB inside a healthy-looking root. 200 GiB is well
+                # above any single in-flight release (~100 GB for a 4K
+                # blu-ray rip) and flags accumulation.
+                alert = "SabnzbdIncompleteLarge";
+                expr = "sabnzbd_incomplete_dir_bytes > 200 * 1024 * 1024 * 1024";
+                for = "30m";
+                labels.severity = "warning";
+                annotations = {
+                  summary = "sabnzbd incomplete dir over 200 GiB on {{ $labels.instance }}";
+                  description = "sabnzbd_incomplete_dir_bytes = {{ $value | humanize1024 }}B for 30m. Either a release got stuck in post-processing or multiple downloads are piling up faster than they're finishing.";
+                };
+              }
+              {
                 alert = "HighCaddy5xx";
                 expr = ''sum by (instance, server) (rate(caddy_http_requests_total{code=~"5.."}[5m])) > 0.1'';
                 for = "5m";
@@ -468,7 +504,7 @@ _: {
                 # web/scheduler/task-queue/consumer), prowlarr, radarr,
                 # readeck, sabnzbd, sonarr, spierscraper, unifi-os-server.
                 + "|audiobookshelf|bazarr|jellyfin|kavita|komga|mealie|miniflux"
-                + "|paperless(-.+)?|prowlarr|radarr|readeck|sabnzbd|sonarr"
+                + "|paperless(-.+)?|prowlarr|radarr|readeck|sabnzbd(-.+)?|sonarr"
                 + "|spierscraper|unifi-os-server"
                 # Container-based apps (modules/apps/*.nix using
                 # virtualisation.oci-containers): each registers a


### PR DESCRIPTION
## Summary

- `download_dir` is now `/var/lib/sabnzbd-incomplete` (preserved on `/persist`, sibling of `/var/lib/sabnzbd` so it stays out of the existing restic path set). par2 verify + unrar read in-flight downloads from local storage instead of bouncing TLS-wrapped NFS RX against simultaneous NFS TX.
- `news.frugalusenet.com` connection cap (50) codified in nix so a fresh deploy doesn't silently revert to the upstream default.
- New textfile-collector publisher (`sabnzbd-incomplete-metrics` oneshot + 5m timer) emits `sabnzbd_incomplete_oldest_seconds` and `sabnzbd_incomplete_dir_bytes`.
- Two new vmalert rules: `SabnzbdIncompleteStale` (>24h, warning) and `SabnzbdIncompleteLarge` (>200 GiB, warning).

Closes #276.

## Test plan

- [x] `task deploy:hpp-1` + `task deploy:amos1` activate cleanly
- [x] Triggered Sonarr MissingEpisodeSearch on amos1 — downloads land in `/var/lib/sabnzbd-incomplete` (`/mnt/content/Downloads/incomplete` stays empty)
- [x] `news.frugalusenet.com` shows `connections = 50` in the merged `sabnzbd.ini`
- [x] Reboot survival on amos1: bind-mount restores from `/@persist`, all 194 pre-reboot files preserved, sabnzbd resumed the queue
- [x] Manual `restic-backups-server.service` run — latest snapshot's `paths` list contains `/var/lib/sabnzbd` but not `/var/lib/sabnzbd-incomplete`; `restic ls` of the snapshot has 0 entries matching `sabnzbd-incomplete`
- [x] Both new alert rules loaded in vmalert's `/api/v1/rules` on hpp-1 and amos1
- [x] Both new metrics scraping in VictoriaMetrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)