### PR TITLE
vmalert hardening: for:1m on HostOOMKill + persist alert state via remoteWrite (closes #239)

### DIFF
--- a/modules/system/victoriametrics.nix
+++ b/modules/system/victoriametrics.nix
@@ -110,6 +110,11 @@ _: {
               {
                 alert = "HostOOMKill";
                 expr = "rate(node_vmstat_oom_kill[5m]) > 0";
+                # The kernel OOM counter is monotonic and doesn't
+                # oscillate, so a 1m confirmation costs nothing but
+                # suppresses single-bad-sample false positives (see #239,
+                # where this fired with the counter flat at 0 all window).
+                for = "1m";
                 labels.severity = "warning";
                 annotations = {
                   summary = "OOM kill on {{ $labels.instance }}";
@@ -718,6 +723,15 @@ _: {
             # Match VM's scrape cadence so `rate()` and `for:` windows
             # behave the same as they did under Prometheus's evaluator.
             "evaluationInterval" = "30s";
+            # Persist alert state back into VictoriaMetrics. Without this
+            # there's no record of what fired once an alert resolves —
+            # #239's false positive left nothing to query after the fact.
+            # remoteWrite emits the `ALERTS` / `ALERTS_FOR_STATE` series
+            # (queryable in vmui for post-hoc correlation); remoteRead
+            # restores pending-alert state across vmalert restarts so a
+            # bounce doesn't reset every `for:` window.
+            "remoteWrite.url" = "http://127.0.0.1:${toString vmPort}";
+            "remoteRead.url" = "http://127.0.0.1:${toString vmPort}";
           };
         };
 


### PR DESCRIPTION
Closes #239.

Two hardening follow-ups from the #239 false-positive investigation (SystemdUnitFailed + HostOOMKill both fired against hpp-1 on 2026-05-20 with the underlying conditions provably false). No recurrence in the ~3 weeks since, so the remaining work was the preventative/diagnostic items, not a live bug.

## Changes

**`HostOOMKill`: add `for: 1m`.** The rule had no `for:` clause, so a single bad sample fired it. The kernel OOM counter is monotonic and doesn't oscillate, so a 1-minute confirmation costs nothing and would have suppressed #239's firing (counter flat at 0 the whole window).

**vmalert: enable `remoteWrite` + `remoteRead` against VictoriaMetrics.** The issue's core diagnostic gap was that nothing recorded *what fired* once an alert resolved (no remoteWrite, no `ALERTS_FOR_STATE` persistence). Now:
- `remoteWrite` emits the `ALERTS` / `ALERTS_FOR_STATE` series back into VM → queryable in vmui for post-hoc correlation next time.
- `remoteRead` restores pending-alert state across vmalert restarts so a bounce doesn't reset every `for:` window.

Note: vmalert's stderr was *already* captured in the journal — it just logs nothing during steady-state evaluation, so the "capture stderr" framing in #239 wouldn't actually have helped. remoteWrite is the real fix for the persistence gap.

The third #239 follow-up (cadvisor/podman storage-race log spam) was already handled separately via #192 / #205.

## Testing

- `nix flake check` — all configs pass.
- `statix` clean on the changed file (the `task check` lint step has a pre-existing unrelated arg-parsing bug; the pre-commit statix hook passes).
- **Deployed to hpp-1**: `vmalert-main.service` active post-switch, both flags live in the unit, no errors in startup log, and `ALERTS_FOR_STATE` now registered as a metric name in VM — confirming the remoteWrite path lands data end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)