### PR TITLE
task: de-duplicate `check` lint onto the git-hooks flake check

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,24 +15,19 @@ tasks:
   default:
     cmd: task --list
     silent: true
-  lint:
-    desc: Run nix linters
-    cmds:
-      - statix check . --ignore result 'modules/hosts/_*-hardware.nix'
-      - deadnix --no-underscore --exclude result 'modules/hosts/_*-hardware.nix' .
   fmt:
     desc: Format all Nix files
     cmds:
       - find . -name '*.nix' -not -path './result/*' -exec nixfmt {} +
-  fmt-check:
-    desc: Check formatting without modifying
-    cmds:
-      - find . -name '*.nix' -not -path './result/*' -exec nixfmt --check {} +
   check:
-    desc: Full pre-push check (format, lint, flake check)
+    desc: Full pre-push check (nixfmt + statix + deadnix + flake eval)
+    # `nix flake check` builds the `checks.<system>.pre-commit` derivation,
+    # which runs nixfmt/statix/deadnix via git-hooks.nix — the single
+    # source of truth for lint config (incl. the hardware-file excludes).
+    # No separate fmt-check/lint tasks: those hand-rolled the same tooling
+    # and drifted out of sync (see #239 follow-up — the statix/deadnix CLI
+    # invocations didn't match the tools' actual flag semantics).
     cmds:
-      - task: fmt-check
-      - task: lint
       - nix flake check --all-systems
   build:
     desc: Build a specific host (default luna)


### PR DESCRIPTION
## Problem

`task check` has been aborting since `6a33003` (#287, merged today) with:

```
task: [lint] statix check . --ignore result 'modules/hosts/_*-hardware.nix'
error: unexpected argument 'modules/hosts/_*-hardware.nix' found
```

That commit added hardware-file excludes to the hand-rolled `lint` task using CLI syntax neither tool actually supports:

- **statix** `-i/--ignore` is **single-value**. `--ignore result '<glob>'` parses the glob as a *second positional `TARGET`*, but `statix check` takes only one (`.`) → hard error that aborts the whole task.
- **deadnix** `--exclude` (v1.3.1) is **variadic and literal-path-only** — no glob/regex. The trailing `.` got swallowed as an exclude *pattern*; matched against every path it excluded everything, so deadnix silently scanned nothing (and it has no `--fail`, so it never failed the task regardless).

The author mirrored the **pre-commit framework's** exclude semantics (correctly declared in `git-hooks.nix`) into raw CLI flags, where those semantics don't apply.

## Fix

Both `lint` lines re-implemented — with wrong semantics — what `git-hooks.nix` already declares correctly and what `nix flake check` already runs via `checks.<system>.pre-commit`. Rather than re-fix the invocations and keep two copies of the exclude list hand-synced, this drops the redundant `lint` and `fmt-check` tasks and lets `check` rely on the flake check. Single source of truth, can't drift.

`fmt` (the apply-formatter) is kept.

## Testing

`nix build .#checks.x86_64-linux.pre-commit -L` runs `pre-commit run --all-files`:

```
deadnix..................................................................Passed
nixfmt...................................................................Passed
statix...................................................................Passed
```

statix passes despite the generated `modules/hosts/_*-hardware.nix` files (which do trip it) — confirming the excludes are honoured through the canonical config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)