### PR TITLE
Add FlareSolverr for Cloudflare-protected indexers

### DIFF
--- a/modules/apps/flaresolverr.nix
+++ b/modules/apps/flaresolverr.nix
@@ -1,0 +1,19 @@
+# FlareSolverr - proxy that solves Cloudflare/DDoS-GUARD challenges so
+# indexers can be scraped. Consumed internally by the *arr stack
+# (prowlarr) and shelfarr, which need it for indexers behind Cloudflare.
+#
+# Native services.flaresolverr from nixpkgs (3.5.x). Stateless — the
+# upstream service keeps no on-disk state (HOME is a RuntimeDirectory),
+# so like decluttarr it has no preservation entry, no backup path, and
+# no recovery task.
+#
+# Internal-only: listens on :8191 with the firewall left closed. Native
+# consumers reach it at http://localhost:8191; podman containers
+# (shelfarr) reach it at http://host.containers.internal:8191 over the
+# already-trusted podman bridge — flaresolverr binds 0.0.0.0 by default,
+# so both paths work without opening the port externally.
+_: {
+  flake.modules.nixos.flaresolverr = {
+    services.flaresolverr.enable = true;
+  };
+}

--- a/modules/profiles/dev-server-apps.nix
+++ b/modules/profiles/dev-server-apps.nix
@@ -84,6 +84,7 @@
         audiobookshelf
         bazarr
         decluttarr
+        flaresolverr
         grimmory
         homeassistant
         jellyfin

--- a/modules/profiles/prod-server-apps.nix
+++ b/modules/profiles/prod-server-apps.nix
@@ -83,6 +83,7 @@
         # an upstream bambuddy<->OrcaSlicer bind bug. Re-add when fixed. See #298.
         bazarr
         decluttarr
+        flaresolverr
         homeassistant
         jellyfin
         komga


### PR DESCRIPTION
## What

Adds [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) — a proxy that solves Cloudflare/DDoS-GUARD challenges so indexers behind them can be scraped. Needed by shelfarr (and useful to prowlarr) for indexers behind Cloudflare.

## Approach

- Uses the **native `services.flaresolverr`** (3.5.0 in the flake's nixos-26.05 pin) rather than a container, per the repo's "prefer nixpkgs services" policy.
- Stateless and internal-only — modeled on `decluttarr` (the closest analogue: an internal *arr-stack helper with no UI, no persistent state). No preservation entry, backup path, or recovery task.
- Firewall left closed. Native consumers reach it at `http://localhost:8191`; podman containers (shelfarr) reach it at `http://host.containers.internal:8191` over the already-trusted bridge — flaresolverr binds `0.0.0.0` by default, so both paths work without opening the port externally.
- Registered in both `dev-server-apps` and `prod-server-apps` profiles.

## Testing

Deployed to hpp-1 via `task deploy:hpp-1`:
- `flaresolverr.service` is `active`; startup browser test passes (bundled Chromium 149), serving on `0.0.0.0:8191`.
- `curl http://localhost:8191/` → `FlareSolverr is ready!` (native path).
- Same probe from inside the shelfarr container via `host.containers.internal:8191` → `FlareSolverr is ready!` (container consumer path).

Still to do post-merge: enable FlareSolverr in prowlarr/shelfarr's indexer settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)