### PR TITLE
Add bookorbit ebook manager (dev)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,10 +477,10 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1781445668,
-        "narHash": "sha256-HrGxtT1N65cDhNwR4Vy35Eb+AxMW0yVHE6OBMqtUAUE=",
+        "lastModified": 1781534789,
+        "narHash": "sha256-D8FLXOU0feyWOc8UrmFg+uYEwllmQJjFFx6BZOLg63g=",
         "ref": "main",
-        "rev": "034d802cd8598e97a6f906546115294e1932ef44",
+        "rev": "7696e6f253875e9a4756ff7a7443df51e5db37bc",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/ianepreston/nix-secrets.git"

--- a/modules/apps/bookorbit-blueprints/bookorbit.yaml
+++ b/modules/apps/bookorbit-blueprints/bookorbit.yaml
@@ -1,0 +1,54 @@
+version: 1
+metadata:
+  name: bookorbit
+entries:
+  - model: authentik_providers_oauth2.oauth2provider
+    id: prov-bookorbit
+    identifiers:
+      name: bookorbit
+    attrs:
+      client_type: confidential
+      client_id: !Env BOOKORBIT_OIDC_CLIENT_ID
+      client_secret: !Env BOOKORBIT_OIDC_CLIENT_SECRET
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-profile"]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+      # authentik 2026.x added OAuth2Provider.grant_types (default empty); the
+      # authorize view rejects flows whose grant is not listed. Required so a
+      # provider created fresh on 2026.x is usable (see komga.yaml for detail).
+      grant_types:
+        - authorization_code
+        - refresh_token
+      redirect_uris:
+        - matching_mode: strict
+          url: https://bookorbit.@serverDomain@/oauth2-callback
+      access_code_validity: minutes=1
+      access_token_validity: minutes=10
+      refresh_token_validity: days=30
+      sub_mode: hashed_user_id
+      issuer_mode: per_provider
+
+  - model: authentik_core.application
+    id: app-bookorbit
+    identifiers:
+      slug: bookorbit
+    attrs:
+      name: BookOrbit
+      provider: !KeyOf prov-bookorbit
+      group: Users
+      meta_launch_url: https://bookorbit.@serverDomain@
+      meta_icon: https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/png/bookorbit.png
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf app-bookorbit
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, Users]]
+      enabled: true

--- a/modules/apps/bookorbit.nix
+++ b/modules/apps/bookorbit.nix
@@ -1,0 +1,178 @@
+# BookOrbit - self-hosted ebook / audiobook / comic library + reader
+# Container; not in nixpkgs (NestJS + Vue, semver git tags but only a
+# rolling `latest` / per-commit `sha-*` on ghcr) — the "container is the
+# fallback" rule applies. The upstream image runs as root, repairs
+# ownership of /data, then drops to PUID:PGID, so we pin those to
+# server-${env}:servers for NFS UID alignment (the library lives on the
+# Synology share at /mnt/content/books, same path komga/kavita read).
+#
+# Postgres via myPostgresApp (TCP + sops `bookorbit/db_password`). The
+# app needs the `uuid-ossp`, `pg_trgm`, and `vector` (pgvector)
+# extensions present in its database. pg_trgm / uuid-ossp ship with the
+# base postgresql package; vector comes from the pgvector plugin wired
+# into services.postgresql.extensions below. None of the three are
+# "trusted" extensions, so `CREATE EXTENSION` needs superuser — the
+# bookorbit-db-extensions oneshot pre-creates them as the postgres
+# superuser before the container starts (the app's own migrations then
+# `CREATE EXTENSION IF NOT EXISTS` as no-ops).
+#
+# OIDC is configured in the app UI (Settings -> OIDC / SSO) and stored
+# in bookorbit's own postgres, not via env — so this registers via
+# myAuthentik.oidcApps with clientCredsInAppEnv = false (audiobookshelf /
+# kavita / readmeabook pattern). After first boot, complete the local
+# admin setup (the SETUP_BOOTSTRAP_TOKEN is sent as the x-setup-token
+# header by the setup wizard), then under Settings -> OIDC / SSO add a
+# provider with:
+#   Issuer:        https://authentik.<serverDomain>/application/o/bookorbit/
+#   Client ID:     bookorbit/oidc_client_id     (in sops)
+#   Client secret: bookorbit/oidc_client_secret (in sops)
+# The redirect URI bookorbit uses is https://bookorbit.<serverDomain>/oauth2-callback
+# (matched strictly by the blueprint provider).
+#
+# The image runs read-only with a dropped cap set (see the compose
+# upstream ships); we replicate that hardening via extraOptions.
+_: {
+  flake.modules.nixos.bookorbit =
+    {
+      config,
+      hostSpec,
+      ...
+    }:
+    let
+      serverUid = config.users.users."server-${hostSpec.serverEnvironment}".uid;
+      serverGid = config.users.groups.servers.gid;
+      bookorbitHost = "bookorbit.${hostSpec.serverDomain}";
+      # 3000 is grafana's on the server hosts; pick a free port and let
+      # the container's PORT match it (publish + caddy + app all agree).
+      port = 3017;
+    in
+    {
+      myPostgresApp.bookorbit.consumerService = [ "podman-bookorbit.service" ];
+
+      myAuthentik.oidcApps.bookorbit = {
+        blueprintsDir = ./bookorbit-blueprints;
+        # OIDC creds are entered in the app UI and persisted in bookorbit's
+        # own postgres, so no client_id/secret in the app env.
+        clientCredsInAppEnv = false;
+        homepage = {
+          group = "Consumption";
+          icon = "bookorbit";
+          description = "Ebook + audiobook library";
+        };
+        displayName = "BookOrbit";
+      };
+
+      sops = {
+        # JWT_SECRET signs login tokens; SETUP_BOOTSTRAP_TOKEN gates the
+        # one-time /auth/setup endpoint. Declared here so the env
+        # template's placeholders resolve; restartUnits lives on the
+        # template only.
+        secrets."bookorbit/jwt_secret".sopsFile = hostSpec.sopsFile;
+        secrets."bookorbit/setup_bootstrap_token".sopsFile = hostSpec.sopsFile;
+
+        # DATABASE_URL embeds the role password, so it (and the two app
+        # secrets) come through sops.templates rather than plain env.
+        templates."bookorbit.env" = {
+          content = ''
+            DATABASE_URL=postgres://bookorbit:${
+              config.sops.placeholder."bookorbit/db_password"
+            }@host.containers.internal:5432/bookorbit
+            JWT_SECRET=${config.sops.placeholder."bookorbit/jwt_secret"}
+            SETUP_BOOTSTRAP_TOKEN=${config.sops.placeholder."bookorbit/setup_bootstrap_token"}
+          '';
+          restartUnits = [ "podman-bookorbit.service" ];
+        };
+      };
+
+      # Make the pgvector .so available to the shared cluster. uuid-ossp
+      # and pg_trgm are bundled with the base postgresql package.
+      services.postgresql.extensions = ps: [ ps.pgvector ];
+
+      # Pre-create the three extensions in bookorbit's db as the postgres
+      # superuser (none are trusted, so the unprivileged role can't).
+      systemd.services.bookorbit-db-extensions = {
+        description = "Create required postgres extensions in the bookorbit database";
+        after = [
+          "postgresql.service"
+          "postgresql-setup.service"
+          "bookorbit-db-password.service"
+        ];
+        requires = [ "postgresql.service" ];
+        wants = [ "postgresql-setup.service" ];
+        wantedBy = [ "podman-bookorbit.service" ];
+        before = [ "podman-bookorbit.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "postgres";
+          Group = "postgres";
+        };
+        script = ''
+          set -euo pipefail
+          ${config.services.postgresql.package}/bin/psql -d bookorbit -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+          CREATE EXTENSION IF NOT EXISTS pg_trgm;
+          CREATE EXTENSION IF NOT EXISTS vector;
+          SQL
+        '';
+      };
+
+      systemd.tmpfiles.rules = [
+        "d /var/lib/containers/bookorbit 0750 ${toString serverUid} ${toString serverGid} -"
+        "d /var/lib/containers/bookorbit/data 0750 ${toString serverUid} ${toString serverGid} -"
+      ];
+
+      virtualisation.oci-containers.containers.bookorbit = {
+        # Upstream publishes semver git releases but only a rolling
+        # `latest` (and per-commit `sha-*`) to ghcr — no semver image
+        # tags — so we pin `latest` to its digest for reproducibility;
+        # renovate tracks `latest` and bumps the digest on its own.
+        # renovate: datasource=docker depName=ghcr.io/bookorbit/bookorbit
+        image = "ghcr.io/bookorbit/bookorbit:latest@sha256:be53a38b88d18c702a7f9759b3fc4e1584f583a66baa9ee0c66a50595fe1611c";
+        ports = [ "127.0.0.1:${toString port}:${toString port}" ];
+        # The image starts as root (caps below), repairs /data ownership,
+        # then drops to PUID:PGID. Don't set `user` — it short-circuits
+        # the entrypoint's permission fix.
+        volumes = [
+          "/var/lib/containers/bookorbit/data:/data"
+          "/mnt/content/books:/books"
+        ];
+        environment = {
+          NODE_ENV = "production";
+          TZ = config.time.timeZone;
+          PORT = toString port;
+          PUID = toString serverUid;
+          PGID = toString serverGid;
+          APP_URL = "https://${bookorbitHost}";
+          # authentik.<serverDomain> resolves to a private/LAN address on
+          # this network; bookorbit rejects local issuer/discovery URLs
+          # unless this is set. Trusted self-hosted IdP, so allow it.
+          OIDC_ALLOW_LOCAL_ISSUERS = "true";
+        };
+        environmentFiles = [ config.sops.templates."bookorbit.env".path ];
+        # Mirror the upstream compose hardening: read-only rootfs with a
+        # tmpfs for /tmp and a minimal cap set (the entrypoint needs
+        # CHOWN/DAC_OVERRIDE/FOWNER/SET[UG]ID to fix /data perms and drop
+        # privileges).
+        extraOptions = [
+          "--init"
+          "--read-only"
+          "--tmpfs=/tmp"
+          "--cap-drop=ALL"
+          "--cap-add=CHOWN"
+          "--cap-add=DAC_OVERRIDE"
+          "--cap-add=FOWNER"
+          "--cap-add=SETGID"
+          "--cap-add=SETUID"
+          "--security-opt=no-new-privileges"
+        ];
+      };
+
+      myCaddy.apps.bookorbit = {
+        host = bookorbitHost;
+        routeConfig = ''
+          reverse_proxy localhost:${toString port}
+        '';
+      };
+    };
+}

--- a/modules/profiles/dev-server-apps.nix
+++ b/modules/profiles/dev-server-apps.nix
@@ -83,6 +83,7 @@
         actualbudget
         audiobookshelf
         bazarr
+        bookorbit
         decluttarr
         flaresolverr
         grimmory

--- a/taskfiles/recovery.yaml
+++ b/taskfiles/recovery.yaml
@@ -321,6 +321,24 @@ tasks:
       - task: _health
         vars: { HOST: '{{.HOST}}', APP: bazarr, URL: 'http://127.0.0.1:6767/', EXPECT: '200', DEST: '{{.DEST}}', SSH_PORT: '{{.SSH_PORT}}' }
 
+  bookorbit:
+    desc: Restore bookorbit (containerized + postgres)
+    requires: { vars: [HOST] }
+    cmds:
+      - task: _restore-pg
+        vars:
+          HOST: '{{.HOST}}'
+          APP: bookorbit
+          UNITS: 'podman-bookorbit.service'
+          PATHS: '/var/lib/containers/bookorbit'
+          DB: bookorbit
+          DEST: '{{.DEST}}'
+          SOURCE_HOST: '{{.SOURCE_HOST}}'
+          SSH_PORT: '{{.SSH_PORT}}'
+          REPO_MOUNT: '{{.REPO_MOUNT}}'
+      - task: _health
+        vars: { HOST: '{{.HOST}}', APP: bookorbit, URL: 'http://127.0.0.1:3017/api/v1/health', EXPECT: '200', DEST: '{{.DEST}}', SSH_PORT: '{{.SSH_PORT}}' }
+
   gatus:
     desc: Restore gatus (native + sqlite-quiesce)
     requires: { vars: [HOST] }
@@ -822,6 +840,7 @@ tasks:
       - task: audiobookshelf
       - task: bambuddy
       - task: bazarr
+      - task: bookorbit
       - task: gatus
       - task: grimmory
       - task: homeassistant


### PR DESCRIPTION
BookOrbit (self-hosted ebook/audiobook/comic library + reader) as a container app: shared postgres + pgvector with a superuser oneshot to create the required uuid-ossp/pg_trgm/vector extensions, NFS-aligned PUID/PGID on the /mnt/content/books library, read-only hardened container mirroring upstream's cap set, and a caddy route.

OIDC is configured in the app UI (stored in bookorbit's own postgres), so it registers via myAuthentik.oidcApps with clientCredsInAppEnv=false; the blueprint creates the authentik provider/app (redirect .../oauth2-callback, Users group).

Host port 3017 (3000 is grafana on the server hosts). Added to the dev-server-apps profile and a recovery:bookorbit dispatcher (restore-pg
+ health). Secrets provisioned for hpp-1 and amos1.